### PR TITLE
fix: fallbacks for missing oracle prices

### DIFF
--- a/src/pages/InterProtocol.tsx
+++ b/src/pages/InterProtocol.tsx
@@ -138,8 +138,7 @@ export function InterProtocol() {
       agg +
       node.allocations.nodes.reduce((agg_, node_) => {
         const allocationInUsd =
-          ((Number(node_.value) / 1_000_000) * Number(oraclePrices[node_.token]?.typeOutAmount || 1_000_000)) /
-          1_000_000;
+          ((Number(node_.value) / 1_000_000) * Number(oraclePrices[node_.token]?.typeOutAmount || 0)) / 1_000_000;
         return agg_ + allocationInUsd;
       }, 0),
     0,
@@ -149,8 +148,7 @@ export function InterProtocol() {
   const totalLockedCollateral = response.vaultManagerMetrics.nodes.reduce((agg, node) => {
     const collateralInUsd =
       ((Number(node.totalCollateral) / 1_000_000) *
-        Number(oraclePrices[node.liquidatingCollateralBrand].typeOutAmount)) /
-      1_000_000;
+        Number(oraclePrices[node.liquidatingCollateralBrand]?.typeOutAmount) || 0) / 1_000_000;
     return agg + collateralInUsd;
   }, 0);
 

--- a/src/pages/Reserve.tsx
+++ b/src/pages/Reserve.tsx
@@ -75,7 +75,7 @@ export const Reserve = () => {
     );
 
     dailyMetricsResponse?.[tokenName].nodes.forEach((dailyTokenMetrics: any) => {
-      const oracle = dailyOracles[dailyTokenMetrics.dateKey] || { typeOutAmountLast: 1, typeInAmountLast: 1 };
+      const oracle = dailyOracles[dailyTokenMetrics.dateKey] || { typeOutAmountLast: 0, typeInAmountLast: 1 };
       graphDataMap[dailyTokenMetrics.dateKey] = {
         ...graphDataMap[dailyTokenMetrics.dateKey],
         x: dailyTokenMetrics.blockTimeLast.slice(0, 10),

--- a/src/pages/Vaults.tsx
+++ b/src/pages/Vaults.tsx
@@ -175,7 +175,7 @@ export function Vaults() {
     );
 
     dailyMetricsResponse?.[tokenName].nodes.forEach((dailyTokenMetrics: any) => {
-      const oracle = dailyOracles[dailyTokenMetrics.dateKey];
+      const oracle = dailyOracles[dailyTokenMetrics.dateKey] || { typeOutAmountLast: 0, typeInAmountLast: 1 };
       graphDataMap[dailyTokenMetrics.dateKey] = {
         ...graphDataMap[dailyTokenMetrics.dateKey],
         x: dailyTokenMetrics.blockTimeLast.slice(0, 10),
@@ -188,7 +188,9 @@ export function Vaults() {
     });
   });
 
-  const sortedGraphDataList = Object.values(graphDataMap).slice().sort((a, b) => a.key - b.key);
+  const sortedGraphDataList = Object.values(graphDataMap)
+    .slice()
+    .sort((a, b) => a.key - b.key);
   let prevValue: GraphData = sortedGraphDataList[0];
   const graphDataList: Array<GraphData> = sortedGraphDataList.reduce(
     (aggArray: Array<GraphData>, graphData: GraphData) => {

--- a/src/widgets/ReserveSummary.tsx
+++ b/src/widgets/ReserveSummary.tsx
@@ -17,8 +17,7 @@ export function ReserveSummary({ title = 'Total Reserve Assets', data, isLoading
     (agg, node) =>
       agg +
       Object.values(node.allocations).reduce((agg_, node_) => {
-        const allocationInUsd =
-          ((Number(node_.value) / 1_000_000) * Number(node_.typeOutAmount || 1_000_000)) / 1_000_000;
+        const allocationInUsd = ((Number(node_.value) / 1_000_000) * Number(node_.typeOutAmount || 0)) / 1_000_000;
         return agg_ + allocationInUsd;
       }, 0),
     0,


### PR DESCRIPTION
This PR adds safety checks in case oracle price is missing for a token. to prevent it from crashing. 