### PR TITLE
fix: updated decimal places logic of total psm assets

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -259,6 +259,12 @@ query {
             priceFeedName
         }
     }
+    boardAuxes {
+        nodes {
+            allegedName
+            decimalPlaces
+        }
+    }
 }`
 
 export const LIQUIDATIONS_DASHBOARD = `


### PR DESCRIPTION
fixes: https://github.com/Agoric/agoric-subql/issues/13

Updates the logic to get the decimal places of anchorPoolBalance and uses that instead of the default 6 decimal places
![image](https://github.com/agoric-labs/agoric-inter-dashboard/assets/8860764/1020408f-f418-42c3-9a43-efe903ebae44)
