### PR TITLE
perf: combine vaults queries

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -57,7 +57,9 @@ query {
         }
     }
     oraclePrices {
-	@@ -129,13 +86,29 @@ query {
+        nodes {
+            priceFeedName
+            typeOutAmount
             typeInAmount
         }
     }


### PR DESCRIPTION
The PR does the following:
- combines  `VAULTS_DASHBOARD_QUERY` , `OPEN_VAULTS_QUERY` and `VAULTS_GRAPH_TOKENS_QUERY` into a single query as these queries had overlapping elements. 
- Chores related naming and declaring types