### PR TITLE
chore: create a seperate component for inter protocol route's fallback ui

### DIFF
--- a/src/components/InterProtocolSkeleton.tsx
+++ b/src/components/InterProtocolSkeleton.tsx
@@ -1,0 +1,51 @@
+import { ErrorAlert } from './ErrorAlert';
+import { PageHeader } from './PageHeader';
+import { PageContent } from './PageContent';
+import { ValueCardGrid } from './ValueCardGrid';
+import { ValueCard } from './ValueCard';
+import { Skeleton } from './ui/skeleton';
+import { SectionHeader } from './SectionHeader';
+
+interface InterProtocolSkeletonProps {
+  error: any;
+  isLoading: boolean;
+}
+
+const firstCards = [
+  'IST in Circulation',
+  'Total Mint Limit',
+  'Total Mint Limit Utilized',
+  'Total Interchain IST',
+  '% of Interchain IST',
+  'Smart Wallets Provisioned',
+];
+
+const InterProtocolSkeleton: React.FC<InterProtocolSkeletonProps> = ({ error, isLoading }) => {
+  if (error) {
+    return <ErrorAlert value={error} />;
+  }
+
+  if (isLoading) {
+    return (
+      <>
+        <PageHeader title="Summary" />
+        <PageContent>
+          <ValueCardGrid>
+            {firstCards.map((title) => (
+              <ValueCard title={title} key={title} value={<Skeleton className="w-[100px] h-[32px] rounded-full" />} />
+            ))}
+          </ValueCardGrid>
+          <SectionHeader>Balances</SectionHeader>
+          <Skeleton className="w-full h-[20px] rounded-full mb-2" />
+          <Skeleton className="w-full h-[20px] rounded-full mb-2" />
+          <Skeleton className="w-full h/[20px] rounded-full mb-2" />
+          <Skeleton className="w-full h-[20px] rounded-full mb-2" />
+        </PageContent>
+      </>
+    );
+  }
+
+  return null;
+};
+
+export default InterProtocolSkeleton;

--- a/src/pages/InterProtocol.tsx
+++ b/src/pages/InterProtocol.tsx
@@ -1,7 +1,6 @@
 import useSWR from 'swr';
 import { AxiosError, AxiosResponse } from 'axios';
 import { PieChart, Pie, Cell, Tooltip } from 'recharts';
-import { Skeleton } from '@/components/ui/skeleton';
 import { SectionHeader } from '@/components/SectionHeader';
 import { ValueCard } from '@/components/ValueCard';
 import { ValueCardGrid } from '@/components/ValueCardGrid';
@@ -9,20 +8,12 @@ import { PageHeader } from '@/components/PageHeader';
 import { PageContent } from '@/components/PageContent';
 import { colors } from '@/components/palette';
 import { formatPercent, roundPrice, formatPrice, formatIST, subQueryFetcher, fetchDataFromUrl } from '@/utils';
-import { ErrorAlert } from '@/components/ErrorAlert';
 import { INTER_DASHBOARD_QUERY } from '@/queries';
 import {
   GET_INTERCHAIN_BALANCES_URL,
 } from '@/constants';
+import InterProtocolSkeleton from '@/components/InterProtocolSkeleton';
 
-const firstCards = [
-  'IST in Circulation',
-  'Total Mint Limit',
-  'Total Mint Limit Utilized',
-  'Total Interchain IST',
-  '% of Interchain IST',
-  'Smart Wallets Provisioned',
-];
 
 const RADIAN = Math.PI / 180;
 
@@ -124,28 +115,8 @@ export function InterProtocol() {
   const error = dashboardError || interchainBalanceError;
   const isLoading = isDashboardLoading || isInterchainBalanceLoading;
 
-
-  if (error) {
-    return <ErrorAlert value={error} />;
-  }
-  if (isLoading) {
-    return (
-      <>
-        <PageHeader title="Summary" />
-        <PageContent>
-          <ValueCardGrid>
-            {firstCards.map((title) => (
-              <ValueCard title={title} key={title} value={<Skeleton className="w-[100px] h-[32px] rounded-full" />} />
-            ))}
-          </ValueCardGrid>
-          <SectionHeader>Balances</SectionHeader>
-          <Skeleton className="w-full h-[20px] rounded-full mb-2" />
-          <Skeleton className="w-full h-[20px] rounded-full mb-2" />
-          <Skeleton className="w-full h-[20px] rounded-full mb-2" />
-          <Skeleton className="w-full h-[20px] rounded-full mb-2" />
-        </PageContent>
-      </>
-    );
+  if (error || isLoading) {
+    return <InterProtocolSkeleton error={error} isLoading={isLoading} />;
   }
 
   const ibcBalance = getInterchainBalance(interchainBalanceData?.data?.balances);


### PR DESCRIPTION
The PR separates fallback UI code from the Inter Protocol's route into its component. This improves maintainability and modularity by isolating changes and enhancing reusability. I plan to follow this pattern for other routes as well. 

Also, later on we can turn this into a reusable component that can be used as fallback UI for all the routes. 