### PR TITLE
feat: added icons to collaterlal types

### DIFF
--- a/src/components/OpenVaultsTable.tsx
+++ b/src/components/OpenVaultsTable.tsx
@@ -2,7 +2,7 @@ import { DataTable, DataColumn } from './DataTable';
 
 type Row = {
   vault_idx: string;
-  collateral_type: string;
+  collateral_type: JSX.Element;
   debt_type: string;
   collateral_amount: number;
   current_collateral_price: number;
@@ -27,7 +27,7 @@ export const columns: DataColumn<Row>[] = [
   },
   {
     accessorKey: 'collateral_type',
-    type: 'text',
+    type: 'markup',
     header: 'Collateral Type',
   },
   {

--- a/src/components/VaultManagersTable.tsx
+++ b/src/components/VaultManagersTable.tsx
@@ -1,7 +1,7 @@
 import { DataTable, DataColumn } from './DataTable';
 
 type Row = {
-  collateral_type: string;
+  collateral_type: JSX.Element;
   debt_type: string;
   total_collateral: number;
   total_collateral_current_usd: number;
@@ -18,7 +18,7 @@ type Props = {
 export const columns: DataColumn<Row>[] = [
   {
     accessorKey: 'collateral_type',
-    type: 'text',
+    type: 'markup',
     header: 'Collateral Type',
   },
   {

--- a/src/components/ui/collateralWithIcon.tsx
+++ b/src/components/ui/collateralWithIcon.tsx
@@ -1,0 +1,10 @@
+import icons from '@/icons';
+
+const CollateralWithIcon = ({ collateralType }: { collateralType: string }) => (
+  <span className="flex">
+    <img src={icons[collateralType.toLowerCase()] || icons.unknown} alt={collateralType} className="w-4 h-4" />{' '}
+    <span className="flex-1 ml-2">{collateralType}</span>
+  </span>
+);
+
+export default CollateralWithIcon;

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -1,0 +1,20 @@
+import atom from './atom.svg';
+import statom from './statom.svg';
+import unknown from './unknown.svg';
+import osmosis from './osmosis.svg';
+import sttia from './sttia.svg';
+import stkdydx from './stkdydx.svg';
+import stkatom from './stkatom.svg';
+
+const icons: { [key: string]: string } = {
+  atom,
+  statom1: atom,
+  statom,
+  stosmo: osmosis,
+  sttia,
+  stkatom,
+  stkdydx,
+  unknown,
+};
+
+export default icons;

--- a/src/widgets/OpenVaults.tsx
+++ b/src/widgets/OpenVaults.tsx
@@ -2,6 +2,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { OpenVaultsTable } from '@/components/OpenVaultsTable';
 import { SectionHeader } from '@/components/SectionHeader';
 import { OpenVaultsData } from '@/pages/Vaults';
+import CollateralWithIcon from '@/components/ui/collateralWithIcon';
 
 type Props = {
   title?: string;
@@ -38,7 +39,7 @@ export function OpenVaults({ title = 'Open Vaults', data, isLoading }: Props) {
     const currentCollateralPrice = vaultData.typeOutAmount / 1_000_000;
     return {
       vault_idx: vaultIdx,
-      collateral_type: vaultData.token,
+      collateral_type: <CollateralWithIcon collateralType={vaultData.token} />,
       debt_type: 'IST',
       collateral_amount: collateralAmount,
       current_collateral_price: currentCollateralPrice,

--- a/src/widgets/TokenPrices.tsx
+++ b/src/widgets/TokenPrices.tsx
@@ -2,25 +2,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { SectionHeader } from '@/components/SectionHeader';
 import { TokenPricesTable } from '@/components/TokenPricesTable';
 import { VaultsDashboardData } from '@/pages/Vaults';
-
-import atom from '../icons/atom.svg';
-import statom from '../icons/statom.svg';
-import unknown from '../icons/unknown.svg';
-import osmosis from '../icons/osmosis.svg';
-import sttia from '../icons/sttia.svg';
-import stkdydx from '../icons/stkdydx.svg';
-import stkatom from '../icons/stkatom.svg';
-
-export const icons: { [key: string]: string } = {
-  atom,
-  statom1: atom,
-  statom,
-  stosmo: osmosis,
-  sttia,
-  stkatom,
-  stkdydx,
-  unknown,
-};
+import CollateralWithIcon from '@/components/ui/collateralWithIcon';
 
 type Props = {
   title?: string;
@@ -56,16 +38,7 @@ export function TokenPrices({ title = 'Summary', data, isLoading }: Props) {
     const changeValue = Math.round(change * 10000) / 100;
 
     return {
-      token: (
-        <span className="flex">
-          <img
-            src={icons[token.liquidatingCollateralBrand.toLowerCase()] || icons.unknown}
-            alt={token.liquidatingCollateralBrand}
-            className="w-4 h-4"
-          />{' '}
-          <span className="flex-1 ml-2">{token.liquidatingCollateralBrand}</span>
-        </span>
-      ),
+      token: <CollateralWithIcon collateralType={token.liquidatingCollateralBrand} />,
       name: token.liquidatingCollateralBrand,
       numActive: token.numActiveVaults,
       oraclePrice: token.typeOutAmount / 1_000_000,

--- a/src/widgets/VaultManagers.tsx
+++ b/src/widgets/VaultManagers.tsx
@@ -2,6 +2,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { VaultManagersTable } from '@/components/VaultManagersTable';
 import { SectionHeader } from '@/components/SectionHeader';
 import { VaultsDashboardData } from '@/pages/Vaults';
+import CollateralWithIcon from '@/components/ui/collateralWithIcon';
 
 type Props = {
   title?: string;
@@ -37,7 +38,7 @@ export function VaultManagers({ title = 'Collateral Type', data, isLoading }: Pr
     const colletarizationRatio = totalCollateralUsd / totalIstMinted;
     const debtLimit = coinData.debtLimit / 1_000_000;
     return {
-      collateral_type: coinName,
+      collateral_type: <CollateralWithIcon collateralType={coinName} />,
       debt_type: 'IST',
       total_collateral: totalCollateral,
       total_collateral_current_usd: totalCollateralUsd,


### PR DESCRIPTION
added icons for collateral types and open vaults tables:
![image](https://github.com/agoric-labs/agoric-inter-dashboard/assets/8860764/c8a18a6f-3427-492d-9fe8-64e5d93d9872)

also refactored the code to create reusable components