### PR TITLE
chore: change props to accept activeVaults directly instead of data

### DIFF
--- a/src/pages/Vaults.tsx
+++ b/src/pages/Vaults.tsx
@@ -201,7 +201,7 @@ export function Vaults() {
       <PageContent>
         <ValueCardGrid>
           <VaultManagerCountCard data={dashboardData} isLoading={isLoading} />
-          <ActiveVaultCountCard data={openVaults} isLoading={isLoading} />
+          <ActiveVaultCountCard activeVaults={openVaults?.length} isLoading={isLoading} />
           <VaultTotalLockedCollateralValueCard data={dashboardData} isLoading={isLoading} />
         </ValueCardGrid>
         <TokenPrices data={dashboardData} isLoading={isLoading} />

--- a/src/widgets/ActiveVaultCountCard.tsx
+++ b/src/widgets/ActiveVaultCountCard.tsx
@@ -1,17 +1,16 @@
 import { Skeleton } from '@/components/ui/skeleton';
 import { ValueCard } from '@/components/ValueCard';
-import { OpenVaultsData } from '@/pages/Vaults';
 
 type Props = {
   title?: string;
-  data: OpenVaultsData;
+  activeVaults: number;
   isLoading: boolean;
 };
 
-export function ActiveVaultCountCard({ title = 'Total Active Vaults', data, isLoading }: Props) {
-  if (isLoading || !data) {
+export function ActiveVaultCountCard({ title = 'Total Active Vaults', activeVaults = 0, isLoading }: Props) {
+  if (isLoading) {
     return <ValueCard title={title} value={<Skeleton className="w-[50px] h-[32px] rounded-full" />} />;
   }
 
-  return <ValueCard title={`${title}`} value={data.length} />;
+  return <ValueCard title={`${title}`} value={activeVaults} />;
 }


### PR DESCRIPTION
The PR simplifies `ActiveVaultCountCard` component props. The component now receives only the data it needs (the count of active vaults), rather than the entire data. 