### PR TITLE
fix: include vaults that missing due to pagination

### DIFF
--- a/src/components/VaultCharts.tsx
+++ b/src/components/VaultCharts.tsx
@@ -60,6 +60,12 @@ export function constructGraph(
 }
 
 export function VaultCharts({ tokenNames, vaultsDataIsLoading, error }: Props) {
+  const {
+    data: dailyMetricsData,
+    isLoading: graphDataIsLoading,
+    error: graphDataError,
+  } = useSWR<AxiosResponse, AxiosError>(tokenNames.length ? VAULTS_DAILY_METRICS_QUERY(tokenNames) : null, subQueryFetcher);
+
   if (vaultsDataIsLoading || error) {
     return (
       <>
@@ -68,12 +74,6 @@ export function VaultCharts({ tokenNames, vaultsDataIsLoading, error }: Props) {
       </>
     );
   }
-
-  const {
-    data: dailyMetricsData,
-    isLoading: graphDataIsLoading,
-    error: graphDataError,
-  } = useSWR<AxiosResponse, AxiosError>(VAULTS_DAILY_METRICS_QUERY(tokenNames), subQueryFetcher);
 
   const dailyMetricsResponse: VaultDailyMetricsQueryResponse = dailyMetricsData?.data?.data;
 

--- a/src/pages/Vaults.tsx
+++ b/src/pages/Vaults.tsx
@@ -139,7 +139,6 @@ export function Vaults() {
   } = useSWR<AxiosResponse, AxiosError>(VAULTS_DASHBOARD_QUERY, subQueryFetcher);
 
   const vaultDataResponse: VaultsDashboardResponse = vaultsData?.data.data;
-  const [vaultsDataAppended, setVaultsDataAppended] = useState<VaultsDashboardResponse | null>(null);
 
   const totalVaultsCount = vaultDataResponse?.vaults.totalCount || 1;
   const pageCount = Math.ceil(totalVaultsCount / 100) - 1;
@@ -147,20 +146,21 @@ export function Vaults() {
     pageCount ? OPEN_VAULTS_NEXT_PAGES_QUERY(pageCount) : null,
     subQueryFetcher,
   );
-  useEffect(() => {
-    if ((pageCount !== 0 && !vaultsNextPages) || !vaultDataResponse) return;
+
+  let vaultsDataAppended: VaultsDashboardResponse | null = null;
+  if (!((pageCount !== 0 && !vaultsNextPages) || !vaultDataResponse)) {
     const vaultPages: {
       [key: string]: {
         nodes: Array<VaultsNode>;
       };
     } = vaultsNextPages?.data.data || {};
     const nextVaults = Object.values(vaultPages).flatMap((openVaultsPage) => openVaultsPage.nodes);
-    
-    setVaultsDataAppended({
+
+    vaultsDataAppended = {
       ...vaultDataResponse,
       vaults: { ...vaultDataResponse.vaults, nodes: [...vaultDataResponse.vaults.nodes, ...nextVaults] },
-    });
-  }, [vaultsNextPages, vaultDataResponse, pageCount]);
+    };
+  }
 
   if (error) {
     return <ErrorAlert value={error} />;

--- a/src/pages/Vaults.tsx
+++ b/src/pages/Vaults.tsx
@@ -189,7 +189,7 @@ export function Vaults() {
         <hr className="my-5" />
         <VaultManagers data={dashboardData} isLoading={isLoading} />
         <hr className="my-5" />
-        <OpenVaults data={openVaults} isLoading={isLoading} />
+        <OpenVaults data={openVaults} isLoading={isLoading || nextPagesIsLoading} />
       </PageContent>
     </>
   );

--- a/src/pages/Vaults.tsx
+++ b/src/pages/Vaults.tsx
@@ -138,7 +138,7 @@ export function Vaults() {
     error,
   } = useSWR<AxiosResponse, AxiosError>(VAULTS_DASHBOARD_QUERY, subQueryFetcher);
 
-  const vaultDataResponse: VaultsDashboardResponse = vaultsData?.data.data;
+  const vaultDataResponse: VaultsDashboardResponse = vaultsData?.data?.data;
 
   const totalVaultsCount = vaultDataResponse?.vaults.totalCount || 1;
   const pageCount = Math.ceil(totalVaultsCount / 100) - 1;

--- a/src/pages/Vaults.tsx
+++ b/src/pages/Vaults.tsx
@@ -142,7 +142,7 @@ export function Vaults() {
 
   const totalVaultsCount = vaultDataResponse?.vaults.totalCount || 1;
   const pageCount = Math.ceil(totalVaultsCount / 100) - 1;
-  const { data: vaultsNextPages } = useSWR<AxiosResponse, AxiosError>(
+  const { data: vaultsNextPages, error: nextPagesError, isLoading: nextPagesIsLoading } = useSWR<AxiosResponse, AxiosError>(
     pageCount ? OPEN_VAULTS_NEXT_PAGES_QUERY(pageCount) : null,
     subQueryFetcher,
   );
@@ -162,8 +162,9 @@ export function Vaults() {
     };
   }
 
-  if (error) {
-    return <ErrorAlert value={error} />;
+  const pageError = error || nextPagesError;
+  if (pageError) {
+    return <ErrorAlert value={pageError} />;
   }
 
   let openVaults: OpenVaultsData = [];
@@ -180,7 +181,7 @@ export function Vaults() {
       <PageContent>
         <ValueCardGrid>
           <VaultManagerCountCard totalCollateralTypes={Object.keys(dashboardData)?.length} isLoading={isLoading} />
-          <ActiveVaultCountCard activeVaults={openVaults?.length} isLoading={isLoading} />
+          <ActiveVaultCountCard activeVaults={openVaults?.length} isLoading={isLoading || nextPagesIsLoading} />
           <VaultTotalLockedCollateralValueCard data={dashboardData} isLoading={isLoading} />
         </ValueCardGrid>
         <TokenPrices data={dashboardData} isLoading={isLoading} />

--- a/src/pages/Vaults.tsx
+++ b/src/pages/Vaults.tsx
@@ -148,19 +148,20 @@ export function Vaults() {
     subQueryFetcher,
   );
   useEffect(() => {
-    if (!vaultsNextPages || !vaultDataResponse) return;
-    const nextVaults = Object.values(
-      vaultsNextPages.data.data as {
-        [key: string]: {
-          nodes: Array<VaultsNode>;
-        };
-      },
-    ).flatMap((openVaultsPage) => openVaultsPage.nodes);
+    if ((pageCount !== 0 && !vaultsNextPages) || !vaultDataResponse) return;
+    const vaultPages: {
+      [key: string]: {
+        nodes: Array<VaultsNode>;
+      };
+    } = vaultsNextPages?.data.data || {};
+    const nextVaults = Object.values(vaultPages).flatMap((openVaultsPage) => openVaultsPage.nodes);
+    
     setVaultsDataAppended({
       ...vaultDataResponse,
       vaults: { ...vaultDataResponse.vaults, nodes: [...vaultDataResponse.vaults.nodes, ...nextVaults] },
     });
-  }, [vaultsNextPages, vaultDataResponse]);
+  }, [vaultsNextPages, vaultDataResponse, pageCount]);
+
   if (error) {
     return <ErrorAlert value={error} />;
   }

--- a/src/pages/Vaults.tsx
+++ b/src/pages/Vaults.tsx
@@ -153,7 +153,7 @@ export function Vaults() {
       [key: string]: {
         nodes: Array<VaultsNode>;
       };
-    } = vaultsNextPages?.data.data || {};
+    } = vaultsNextPages?.data?.data || {};
     const nextVaults = Object.values(vaultPages).flatMap((openVaultsPage) => openVaultsPage.nodes);
 
     vaultsDataAppended = {
@@ -174,22 +174,23 @@ export function Vaults() {
   if (vaultsDataAppended && Object.keys(vaultsDataAppended).length > 0) {
     [openVaults, dashboardData, tokenNames] = processVaultsData(vaultsDataAppended);
   }
+  const dataIsLoading = isLoading || nextPagesIsLoading;
 
   return (
     <>
       <PageHeader title="Vaults" />
       <PageContent>
         <ValueCardGrid>
-          <VaultManagerCountCard totalCollateralTypes={Object.keys(dashboardData)?.length} isLoading={isLoading} />
-          <ActiveVaultCountCard activeVaults={openVaults?.length} isLoading={isLoading || nextPagesIsLoading} />
-          <VaultTotalLockedCollateralValueCard data={dashboardData} isLoading={isLoading} />
+          <VaultManagerCountCard totalCollateralTypes={Object.keys(dashboardData)?.length} isLoading={dataIsLoading} />
+          <ActiveVaultCountCard activeVaults={openVaults?.length} isLoading={dataIsLoading} />
+          <VaultTotalLockedCollateralValueCard data={dashboardData} isLoading={dataIsLoading} />
         </ValueCardGrid>
-        <TokenPrices data={dashboardData} isLoading={isLoading} />
-        <VaultCharts tokenNames={tokenNames} vaultsDataIsLoading={isLoading} error={error} />
+        <TokenPrices data={dashboardData} isLoading={dataIsLoading} />
+        <VaultCharts tokenNames={tokenNames} vaultsDataIsLoading={dataIsLoading} error={error} />
         <hr className="my-5" />
-        <VaultManagers data={dashboardData} isLoading={isLoading} />
+        <VaultManagers data={dashboardData} isLoading={dataIsLoading} />
         <hr className="my-5" />
-        <OpenVaults data={openVaults} isLoading={isLoading || nextPagesIsLoading} />
+        <OpenVaults data={openVaults} isLoading={dataIsLoading} />
       </PageContent>
     </>
   );

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1,4 +1,4 @@
-import { getDateKey } from "./utils";
+import { getDateKey, range } from "./utils";
 
 export const PSM_DASHBOARD_QUERY = `
 query {
@@ -85,6 +85,7 @@ query {
             state
             debt
         }
+        totalCount
     }
     oraclePriceDailies(filter: {
         dateKey: { 
@@ -99,6 +100,19 @@ query {
         }
     }
 }`;
+
+export const OPEN_VAULTS_NEXT_PAGES_QUERY = (pages: number) => `
+query {
+    ${range(pages).map(index => `v${index}:vaults(filter: {state: {equalTo: "active"}}, first: 100, offset:${(index + 1) * 100}) {
+        nodes {
+            id
+            denom
+            balance
+            state
+            debt
+        }
+    }`)}
+}`
 
 export const VAULTS_DAILY_METRICS_QUERY = (tokens: string[]) => `
 query {

--- a/src/types/vault-types.ts
+++ b/src/types/vault-types.ts
@@ -61,6 +61,7 @@ export type VaultsDashboardResponse = {
   vaultManagerGovernances: { nodes: Array<VaultManagerGovernancesNode> };
   vaults: {
     nodes: Array<VaultsNode>;
+    totalCount: number;
   };
   oraclePriceDailies: { nodes: Array<OraclePriceDailiesNode> };
 };


### PR DESCRIPTION
Fixes: #69 

It adds all vaults that are missing due to page limit of graphql

the solution is to perform extra queries that get those missing vaults