### PR TITLE
Feat: add liquidation ration data to liquidations table

### DIFF
--- a/src/components/LiquidatedVaultsTable.tsx
+++ b/src/components/LiquidatedVaultsTable.tsx
@@ -50,16 +50,16 @@ export const columns: DataColumn<Row>[] = [
     type: 'number',
     header: 'IST Debt Amount',
   },
-  // {
-  //   accessorKey: 'liquidation_margin_avg',
-  //   type: 'percent',
-  //   header: 'Liquidation Ratio',
-  // },
-  // {
-  //   accessorKey: 'liquidating_rate',
-  //   type: 'usd',
-  //   header: 'Liquidation Price',
-  // },
+  {
+    accessorKey: 'liquidation_margin_avg',
+    type: 'percent',
+    header: 'Liquidation Ratio',
+  },
+  {
+    accessorKey: 'liquidating_rate',
+    type: 'usd',
+    header: 'Liquidation Price',
+  },
   {
     accessorKey: 'liquidated_return_amount',
     type: 'number',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,6 +11,7 @@ export const VBANK_RESERVE_ACCOUNT = 'vbank/reserve';
 export const GRAPH_DAYS = 90;
 
 export const SUBQUERY_URL = 'https://api.subquery.network/sq/agoric-labs/agoric-mainnet-v2';
+export const SUBQUERY_STAGING_URL = 'https://api.subquery.network/sq/agoric-labs/agoric-mainnet-v2__YWdvc';
 
 export const enum VAULT_STATES {
   ACTIVE = 'active',

--- a/src/pages/Liquidated.tsx
+++ b/src/pages/Liquidated.tsx
@@ -13,7 +13,6 @@ import {
   LiquidationDashboardResponse,
   LiquidationMetricsDailyResponse,
   TokenNamesResponse,
-  VaultManagerGovernancesNode,
 } from '@/types/liquidation-types';
 import { GRAPH_DAYS, SUBQUERY_STAGING_URL } from '@/constants';
 
@@ -25,18 +24,7 @@ export function Liquidated() {
   );
   const response: LiquidationDashboardResponse = data?.data?.data;
 
-  const vaultManagerGovernances: { [key: string]: VaultManagerGovernancesNode } =
-    response?.vaultManagerGovernances?.nodes?.reduce((agg, node) => {
-      const idSegments = node?.id?.split('.');
-      if (idSegments.length < 4) {
-        throw new Error(`Node ID does not contain enough segments: ${node.id}`);
-      }
-      const managerName = idSegments.slice(0, 4).join('.');
-      return { ...agg, [managerName]: node };
-    }, {});
-
   const liquidationDashboardData = {
-    vaultManagerGovernances,
     vaultLiquidations: response?.vaultLiquidations?.nodes,
   };
 

--- a/src/pages/Liquidated.tsx
+++ b/src/pages/Liquidated.tsx
@@ -8,14 +8,21 @@ import { LiquidatedVaultCountCard } from '@/widgets/LiquidatedVaultCountCard';
 import { VaultStatesChart } from '@/widgets/VaultStatesChart';
 import { populateMissingDays, subQueryFetcher } from '@/utils';
 import { LIQUIDATIONS_DASHBOARD, LIQUIDATION_GRAPH_TOKENS_QUERY, LIQUIDATION_DAILY_METRICS_QUERY } from '@/queries';
-import { GraphData, LiquidationDashboardResponse, LiquidationMetricsDailyResponse, OraclePriceNode, TokenNamesResponse, VaultManagerGovernancesNode } from '@/types/liquidation-types';
-import { GRAPH_DAYS } from '@/constants';
-
+import {
+  GraphData,
+  LiquidationDashboardResponse,
+  LiquidationMetricsDailyResponse,
+  TokenNamesResponse,
+  VaultManagerGovernancesNode,
+} from '@/types/liquidation-types';
+import { GRAPH_DAYS, SUBQUERY_STAGING_URL } from '@/constants';
 
 const sum = (items: Array<string>) => items.reduce((agg, next) => agg + Number(next), 0);
 
 export function Liquidated() {
-  const { data, isLoading } = useSWR<AxiosResponse, AxiosError>(LIQUIDATIONS_DASHBOARD, subQueryFetcher);
+  const { data, isLoading } = useSWR<AxiosResponse, AxiosError>(LIQUIDATIONS_DASHBOARD, (query: string) =>
+    subQueryFetcher(query, SUBQUERY_STAGING_URL),
+  );
   const response: LiquidationDashboardResponse = data?.data?.data;
 
   const vaultManagerGovernances: { [key: string]: VaultManagerGovernancesNode } =
@@ -27,22 +34,14 @@ export function Liquidated() {
       const managerName = idSegments.slice(0, 4).join('.');
       return { ...agg, [managerName]: node };
     }, {});
-  const oraclePrices: { [key: string]: OraclePriceNode } = response?.oraclePrices?.nodes?.reduce(
-    (agg, node) => ({ ...agg, [node.typeInName]: node }),
-    {},
-  );
 
   const liquidationDashboardData = {
     vaultManagerGovernances,
     vaultLiquidations: response?.vaultLiquidations?.nodes,
-    oraclePrices,
   };
 
   //  Queries for graph
-  const { data: tokenNamesData } = useSWR<AxiosResponse, AxiosError>(
-    LIQUIDATION_GRAPH_TOKENS_QUERY,
-    subQueryFetcher,
-  );
+  const { data: tokenNamesData } = useSWR<AxiosResponse, AxiosError>(LIQUIDATION_GRAPH_TOKENS_QUERY, subQueryFetcher);
   const tokenNamesResponse: TokenNamesResponse = tokenNamesData?.data.data;
   const tokenNames = tokenNamesResponse?.vaultManagerMetrics.nodes.map((node) => node.liquidatingCollateralBrand) || [];
 
@@ -71,7 +70,7 @@ export function Liquidated() {
   });
 
   const graphDataList = populateMissingDays(graphDataMap, GRAPH_DAYS);
- 
+
   const summedGraphDataList = graphDataList.map((item) => ({
     ...item,
     active: sum(Object.values(item.active)),

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -303,6 +303,7 @@ query {
             state
             balance
             blockTime
+            oraclePrice
             currentState {
                 id
                 denom
@@ -319,16 +320,6 @@ query {
                 balance
                 blockTime
             }
-        }
-    }
-    oraclePrices {
-        nodes {
-            id
-            typeInName
-            typeOutName
-            typeInAmount
-            typeOutAmount
-            priceFeedName
         }
     }
 }`;
@@ -356,23 +347,6 @@ query {
             numLiquidationsCompletedLast
             numLiquidationsAbortedLast
             liquidatingCollateralBrand
-        }
-    }`)}
-}`
-
-export const LIQUIDATION_ORACLE_PRICES_DAILIES_QUERY = (tokens: {[key:string]: number[]}) => `
-query {
-    ${Object.entries(tokens)?.map(([token, oracleKeys]) => 
-    `${token}:oraclePriceDailies (filter: {
-        dateKey: { in: [${oracleKeys.join(', ')}] }, typeInName: {equalTo: "${token}"}
-    }) {
-        nodes {
-            id
-            typeInName
-            typeOutName
-            typeInAmountLast
-            typeOutAmountLast
-            dateKey
         }
     }`)}
 }`

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -287,14 +287,6 @@ query {
             numLiquidatingVaults
         }
     }
-    vaultManagerGovernances  {
-        nodes {
-            id
-            liquidationMarginNumerator
-            liquidationMarginDenominator
-        }
-    }
-
     vaultLiquidations (filter: {state: {equalTo: "liquidated"}}) {
         nodes {
             id
@@ -304,6 +296,7 @@ query {
             balance
             blockTime
             oraclePrice
+            vaultManagerGovernance
             currentState {
                 id
                 denom

--- a/src/types/liquidation-types.ts
+++ b/src/types/liquidation-types.ts
@@ -32,6 +32,10 @@ export type VaultLiquidationsNode = {
   blockTime: string;
   currentState: VaultsNode;
   liquidatingState: VaultLiquidationsNode;
+  oraclePrice: {
+    typeInAmount: string;
+    typeOutAmount: string;
+  };
 };
 
 export type OraclePriceNode = {

--- a/src/types/liquidation-types.ts
+++ b/src/types/liquidation-types.ts
@@ -63,8 +63,6 @@ export type LiquidationDashboardResponse = {
 };
 export type LiquidationDashboardData = {
   vaultLiquidations: Array<VaultLiquidationsNode>;
-  vaultManagerGovernances: { [key: string]: VaultManagerGovernancesNode };
-  oraclePrices: { [key: string]: OraclePriceNode };
 };
 
 export type TokenNamesResponse = {

--- a/src/types/liquidation-types.ts
+++ b/src/types/liquidation-types.ts
@@ -36,6 +36,10 @@ export type VaultLiquidationsNode = {
     typeInAmount: string;
     typeOutAmount: string;
   };
+  vaultManagerGovernance: {
+    liquidationMarginNumerator: string;
+    liquidationMarginDenominator: string;
+  };
 };
 
 export type OraclePriceNode = {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -161,9 +161,9 @@ export const fetchData = async (options: RequestOptions): Promise<AxiosResponse>
   }
 };
 
-export const subQueryFetcher = (query: string) => {
-  const options = {
-    url: SUBQUERY_URL,
+export const subQueryFetcher = (query: string, url: string = SUBQUERY_URL): Promise<AxiosResponse> => {
+  const options: RequestOptions = {
+    url,
     method: RequestMethod.POST,
     data: { query },
   };
@@ -247,3 +247,5 @@ export function createNumberWithLeadingZeroes(numOfZeroes: number) {
     return Math.pow(10, numOfZeroes);
   }
 }
+
+export const parseBigInt = (str: string) => Number(str.slice(0, -1))

--- a/src/widgets/LiquidatedVaults.tsx
+++ b/src/widgets/LiquidatedVaults.tsx
@@ -13,7 +13,6 @@ type Props = {
 };
 
 export function LiquidatedVaults({ title = 'Liquidated Vaults', data, isLoading }: Props) {
-
   if (isLoading || !data) {
     return (
       <>
@@ -37,13 +36,13 @@ export function LiquidatedVaults({ title = 'Liquidated Vaults', data, isLoading 
     const vaultIdRegexMatch = vaultIdRegex.exec(vaultData?.id);
     if (vaultIdRegexMatch === null) throw new Error('Vault ID format invalid');
 
-    const [, vaultManager, vaultIdx] = vaultIdRegexMatch;
+    const vaultIdx = vaultIdRegexMatch[2];
 
     const vaultStateSuffix = vaultData?.currentState?.state === VAULT_STATES.CLOSED ? ' (Closed)' : '';
     const vaultState = vaultData.state[0].toUpperCase() + vaultData.state.slice(1) + vaultStateSuffix;
-    const vaultManagerGovernance = data.vaultManagerGovernances[vaultManager];
     const liquidationRatio =
-      vaultManagerGovernance.liquidationMarginNumerator / vaultManagerGovernance.liquidationMarginDenominator;
+      parseBigInt(vaultData.vaultManagerGovernance?.liquidationMarginNumerator) /
+      parseBigInt(vaultData.vaultManagerGovernance?.liquidationMarginDenominator);
     const istDebtAmount = vaultData.liquidatingState.debt / 1_000_000;
     const collateralAmount = vaultData.liquidatingState.balance / 1_000_000;
     const liquidationPrice = (istDebtAmount * liquidationRatio) / collateralAmount;
@@ -74,7 +73,7 @@ export function LiquidatedVaults({ title = 'Liquidated Vaults', data, isLoading 
       collateral_type: vaultData.denom,
       state: vaultState,
       liquidating_debt_amount_avg: istDebtAmount,
-      liquidation_margin_avg: liquidationRatio, // ??
+      liquidation_margin_avg: liquidationRatio,
       liquidating_rate: liquidationPrice,
       liquidationStartTime,
       liquidationTime,

--- a/tests/Liquidated.test.tsx
+++ b/tests/Liquidated.test.tsx
@@ -5,10 +5,8 @@ import { Liquidated } from '@/pages/Liquidated';
 import {
   LIQUIDATIONS_DASHBOARD,
   LIQUIDATION_GRAPH_TOKENS_QUERY,
-  LIQUIDATION_ORACLE_PRICES_DAILIES_QUERY,
 } from '@/queries';
-import { graphDataMock, dashboardDataMock, graphNodesDataMock, oraclePriceDailies } from './__mocks__/Liquidated';
-import { getDateKey } from '@/utils';
+import { graphDataMock, dashboardDataMock, graphNodesDataMock } from './__mocks__/Liquidated';
 
 jest.mock('swr', () => ({
   default: jest.fn(),
@@ -35,19 +33,10 @@ jest.mock('recharts', () => {
 describe('Liquidation Dashboard Snapshot tests', () => {
   it('should match snapshot when data is loaded', async () => {
     (useSWR as any).mockImplementation((query: string) => {
-      const oraclePricesDatekeyMap = dashboardDataMock.data.data.vaultLiquidations.nodes.reduce(
-        (agg: { [key: string]: Array<number> }, vault) => {
-          const { denom } = vault;
-          const prevDenomKeys = agg[denom] || [];
-          return { ...agg, [denom]: [...prevDenomKeys, getDateKey(new Date(vault.blockTime)).key] };
-        },
-        {},
-      );
       const mockData =
         {
           [LIQUIDATIONS_DASHBOARD]: dashboardDataMock,
           [LIQUIDATION_GRAPH_TOKENS_QUERY]: graphNodesDataMock,
-          [LIQUIDATION_ORACLE_PRICES_DAILIES_QUERY(oraclePricesDatekeyMap)]: oraclePriceDailies,
         }[query] || graphDataMock;
       return { data: mockData, error: null, isLoading: false };
     });

--- a/tests/__mocks__/Liquidated.ts
+++ b/tests/__mocks__/Liquidated.ts
@@ -45,35 +45,6 @@ export const dashboardDataMock = {
           },
         ],
       },
-      vaultManagerGovernances: {
-        nodes: [
-          {
-            id: 'published.vaultFactory.managers.manager3.governance',
-            liquidationMarginNumerator: '19000',
-            liquidationMarginDenominator: '10000',
-          },
-          {
-            id: 'published.vaultFactory.managers.manager1.governance',
-            liquidationMarginNumerator: '16000',
-            liquidationMarginDenominator: '10000',
-          },
-          {
-            id: 'published.vaultFactory.managers.manager2.governance',
-            liquidationMarginNumerator: '17000',
-            liquidationMarginDenominator: '10000',
-          },
-          {
-            id: 'published.vaultFactory.managers.manager0.governance',
-            liquidationMarginNumerator: '15000',
-            liquidationMarginDenominator: '10000',
-          },
-          {
-            id: 'published.vaultFactory.managers.manager4.governance',
-            liquidationMarginNumerator: '16000',
-            liquidationMarginDenominator: '10000',
-          },
-        ],
-      },
       vaultLiquidations: {
         nodes: [
           {
@@ -83,6 +54,14 @@ export const dashboardDataMock = {
             state: 'liquidated',
             balance: '0',
             blockTime: '2024-04-13T21:24:23.592',
+            oraclePrice: {
+              typeInAmount: '1000000n',
+              typeOutAmount: '1230000n',
+            },
+            vaultManagerGovernance: {
+              liquidationMarginDenominator: '10000n',
+              liquidationMarginNumerator: '19000n',
+            },
             currentState: {
               id: 'published.vaultFactory.managers.manager1.vaults.vault83',
               denom: 'stATOM',
@@ -107,6 +86,14 @@ export const dashboardDataMock = {
             state: 'liquidated',
             balance: '615181733',
             blockTime: '2024-04-12T20:24:04.733',
+            oraclePrice: {
+              typeInAmount: '1000000n',
+              typeOutAmount: '1030000n',
+            },
+            vaultManagerGovernance: {
+              liquidationMarginDenominator: '10000n',
+              liquidationMarginNumerator: '10000n',
+            },
             currentState: {
               id: 'published.vaultFactory.managers.manager3.vaults.vault6',
               denom: 'stTIA',
@@ -132,6 +119,14 @@ export const dashboardDataMock = {
             state: 'liquidated',
             balance: '2586376',
             blockTime: '2023-08-17T23:24:06.377',
+            oraclePrice: {
+              typeInAmount: '1000000n',
+              typeOutAmount: '1698900n',
+            },
+            vaultManagerGovernance: {
+              liquidationMarginDenominator: '10000n',
+              liquidationMarginNumerator: '23000n',
+            },
             currentState: {
               id: 'published.vaultFactory.managers.manager0.vaults.vault44',
               denom: 'ATOM',
@@ -157,6 +152,14 @@ export const dashboardDataMock = {
             state: 'liquidated',
             balance: '16',
             blockTime: '2024-04-19T04:24:02.792',
+            oraclePrice: {
+              typeInAmount: '1000000n',
+              typeOutAmount: '1200000n',
+            },
+            vaultManagerGovernance: {
+              liquidationMarginDenominator: '10000n',
+              liquidationMarginNumerator: '17000n',
+            },
             currentState: {
               id: 'published.vaultFactory.managers.manager2.vaults.vault38',
               denom: 'stOSMO',
@@ -182,6 +185,14 @@ export const dashboardDataMock = {
             state: 'liquidated',
             balance: '0',
             blockTime: '2023-11-22T11:24:03.903',
+            oraclePrice: {
+              typeInAmount: '1000000n',
+              typeOutAmount: '2230000n',
+            },
+            vaultManagerGovernance: {
+              liquidationMarginDenominator: '10000n',
+              liquidationMarginNumerator: '20000n',
+            },
             currentState: {
               id: 'published.vaultFactory.managers.manager4.vaults.vault24',
               denom: 'stkATOM',
@@ -198,50 +209,6 @@ export const dashboardDataMock = {
               balance: '16156761',
               blockTime: '2023-11-21T23:00:04.758',
             },
-          },
-        ],
-      },
-      oraclePrices: {
-        nodes: [
-          {
-            id: 'stATOM-USD',
-            typeInName: 'stATOM',
-            typeOutName: 'USD',
-            typeInAmount: '1000000',
-            typeOutAmount: '11478585',
-            priceFeedName: 'stATOM-USD',
-          },
-          {
-            id: 'stOSMO-USD',
-            typeInName: 'stOSMO',
-            typeOutName: 'USD',
-            typeInAmount: '1000000',
-            typeOutAmount: '1079786',
-            priceFeedName: 'stOSMO-USD',
-          },
-          {
-            id: 'ATOM-USD',
-            typeInName: 'ATOM',
-            typeOutName: 'USD',
-            typeInAmount: '1000000',
-            typeOutAmount: '8448340',
-            priceFeedName: 'ATOM-USD',
-          },
-          {
-            id: 'stkATOM-USD',
-            typeInName: 'stkATOM',
-            typeOutName: 'USD',
-            typeInAmount: '1000000',
-            typeOutAmount: '10775043',
-            priceFeedName: 'stkATOM-USD',
-          },
-          {
-            id: 'stTIA-USD',
-            typeInName: 'stTIA',
-            typeOutName: 'USD',
-            typeInAmount: '1000000',
-            typeOutAmount: '9255084',
-            priceFeedName: 'stTIA-USD',
           },
         ],
       },
@@ -4150,52 +4117,6 @@ export const graphDataMock = {
             numLiquidationsCompletedLast: '0',
             numLiquidationsAbortedLast: '0',
             liquidatingCollateralBrand: 'stTIA',
-          },
-        ],
-      },
-    },
-  },
-};
-
-export const oraclePriceDailies = {
-  data: {
-    data: {
-      ATOM: {
-        nodes: [
-          {
-            id: 'ATOM-USD:20230817',
-            typeInName: 'ATOM',
-            typeOutName: 'USD',
-            typeInAmountLast: '1000000',
-            typeOutAmountLast: '7424017',
-            dateKey: 20230817,
-          },
-        ],
-      },
-      stATOM: {
-        nodes: [
-          {
-            id: 'stATOM-USD:20240413',
-            typeInName: 'stATOM',
-            typeOutName: 'USD',
-            typeInAmountLast: '1000000',
-            typeOutAmountLast: '10861897',
-            dateKey: 20240413,
-          },
-        ],
-      },
-      stOSMO: {
-        nodes: [],
-      },
-      stTIA: {
-        nodes: [
-          {
-            id: 'stTIA-USD:20240412',
-            typeInName: 'stTIA',
-            typeOutName: 'USD',
-            typeInAmountLast: '1000000',
-            typeOutAmountLast: '9020684',
-            dateKey: 20240412,
           },
         ],
       },

--- a/tests/__snapshots__/Liquidated.test.tsx.snap
+++ b/tests/__snapshots__/Liquidated.test.tsx.snap
@@ -140,6 +140,36 @@ exports[`Liquidation Dashboard Snapshot tests should match snapshot when data is
                   <div
                     class="text-right"
                   >
+                    Liquidation Ratio
+                  </div>
+                </button>
+              </th>
+              <th
+                class="h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0"
+                style="width: 150px;"
+              >
+                <button
+                  class="text-left w-full"
+                  type="button"
+                >
+                  <div
+                    class="text-right"
+                  >
+                    Liquidation Price
+                  </div>
+                </button>
+              </th>
+              <th
+                class="h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0"
+                style="width: 150px;"
+              >
+                <button
+                  class="text-left w-full"
+                  type="button"
+                >
+                  <div
+                    class="text-right"
+                  >
                     Collateral Returned Amount
                   </div>
                 </button>
@@ -208,6 +238,24 @@ exports[`Liquidation Dashboard Snapshot tests should match snapshot when data is
                 <div
                   class="text-right font-medium"
                 >
+                  230%
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
+                  $8.72
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
                   4.042
                 </div>
               </td>
@@ -217,7 +265,7 @@ exports[`Liquidation Dashboard Snapshot tests should match snapshot when data is
                 <div
                   class="text-right font-medium"
                 >
-                  $30.00
+                  $6.87
                 </div>
               </td>
             </tr>
@@ -265,6 +313,24 @@ exports[`Liquidation Dashboard Snapshot tests should match snapshot when data is
                 <div
                   class="text-right font-medium"
                 >
+                  190%
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
+                  $13.46
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
                   3.749
                 </div>
               </td>
@@ -274,7 +340,7 @@ exports[`Liquidation Dashboard Snapshot tests should match snapshot when data is
                 <div
                   class="text-right font-medium"
                 >
-                  $40.72
+                  $4.61
                 </div>
               </td>
             </tr>
@@ -322,6 +388,24 @@ exports[`Liquidation Dashboard Snapshot tests should match snapshot when data is
                 <div
                   class="text-right font-medium"
                 >
+                  200%
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
+                  $26.03
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
                   16.157
                 </div>
               </td>
@@ -331,7 +415,7 @@ exports[`Liquidation Dashboard Snapshot tests should match snapshot when data is
                 <div
                   class="text-right font-medium"
                 >
-                  $174.09
+                  $36.03
                 </div>
               </td>
             </tr>
@@ -371,6 +455,24 @@ exports[`Liquidation Dashboard Snapshot tests should match snapshot when data is
                   class="text-right font-medium"
                 >
                   0.001
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
+                  170%
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
+                  $1.13
                 </div>
               </td>
               <td
@@ -436,6 +538,24 @@ exports[`Liquidation Dashboard Snapshot tests should match snapshot when data is
                 <div
                   class="text-right font-medium"
                 >
+                  100%
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
+                  $4.92
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
                   921.651
                 </div>
               </td>
@@ -445,7 +565,7 @@ exports[`Liquidation Dashboard Snapshot tests should match snapshot when data is
                 <div
                   class="text-right font-medium"
                 >
-                  $8,313.92
+                  $949.30
                 </div>
               </td>
             </tr>


### PR DESCRIPTION
made two updates to the Liquidations dashboard:

- updated the oraclePrice used for "collateral value returned usd"
- added back "Liquidation ratio" and "Liquidation Price" after fixing the vaultGovernance snapshot

![image](https://github.com/agoric-labs/agoric-inter-dashboard/assets/8860764/7646dfd1-1566-4e46-b588-8b6e0ac2b32a)
