### PR TITLE
chore: decimal places on the psm page

### DIFF
--- a/src/pages/PSM.tsx
+++ b/src/pages/PSM.tsx
@@ -6,12 +6,12 @@ import { PSMStats } from '@/widgets/PSMStats';
 import { PSMMintedPoolBalancePie } from '@/widgets/PSMMintedPoolBalancePie';
 import { populateMissingDays, subQueryFetcher } from '@/utils';
 import { PSM_DASHBOARD_QUERY, PSM_GRAPH_TOKENS_QUERY, PSM_TOKEN_DAILY_MINT_QUERY } from '@/queries';
-import { PsmMetricsResponse, PsmMetricsDailyResponse, GraphData } from '@/types/psm-types';
+import { PsmMetricsResponse, PsmMetricsDailyResponse, GraphData, PSMDashboardResponse } from '@/types/psm-types';
 import { GRAPH_DAYS } from '@/constants';
 
 export const PSM = () => {
   const { data, error, isLoading } = useSWR<AxiosResponse, AxiosError>(PSM_DASHBOARD_QUERY, subQueryFetcher);
-  const response = data?.data?.data;
+  const response: PSMDashboardResponse = data?.data?.data;
   const queryData: { [key: string]: object } = {};
 
   response?.psmMetrics?.nodes?.forEach((node: { denom: string }) => {
@@ -20,6 +20,11 @@ export const PSM = () => {
   response?.psmGovernances?.nodes?.forEach((node: { denom: string }) => {
     if (node.denom in queryData) queryData[node.denom] = { ...queryData[node.denom], ...node };
   });
+
+  const boardAuxes: { [key: string]: number } = response?.boardAuxes?.nodes?.reduce(
+    (agg, node) => ({ ...agg, [node.allegedName]: node.decimalPlaces }),
+    {},
+  );
 
   //  Queries for graph
   const { data: tokenNamesData } = useSWR<AxiosResponse, AxiosError>(PSM_GRAPH_TOKENS_QUERY, subQueryFetcher);
@@ -42,7 +47,7 @@ export const PSM = () => {
       };
     });
   });
-  
+
   const graphDataList = populateMissingDays(graphDataMap, GRAPH_DAYS);
 
   return (

--- a/src/pages/PSM.tsx
+++ b/src/pages/PSM.tsx
@@ -4,7 +4,7 @@ import { PageHeader } from '@/components/PageHeader';
 import { PageContent } from '@/components/PageContent';
 import { PSMStats } from '@/widgets/PSMStats';
 import { PSMMintedPoolBalancePie } from '@/widgets/PSMMintedPoolBalancePie';
-import { populateMissingDays, subQueryFetcher } from '@/utils';
+import { getTokenDivisor, populateMissingDays, subQueryFetcher } from '@/utils';
 import { PSM_DASHBOARD_QUERY, PSM_GRAPH_TOKENS_QUERY, PSM_TOKEN_DAILY_MINT_QUERY } from '@/queries';
 import { PsmMetricsResponse, PsmMetricsDailyResponse, GraphData, PSMDashboardResponse } from '@/types/psm-types';
 import { GRAPH_DAYS } from '@/constants';
@@ -39,11 +39,13 @@ export const PSM = () => {
   const graphDataMap: { [key: number]: GraphData } = {};
   Object.values(dailyMetricsResponse || {}).forEach((tokenDataList) => {
     tokenDataList?.nodes.forEach((dailyTokenMetrics) => {
+      const tokenDivisor = getTokenDivisor(boardAuxes, dailyTokenMetrics.denom);
+
       graphDataMap[dailyTokenMetrics.dateKey] = {
         ...graphDataMap[dailyTokenMetrics.dateKey],
         x: dailyTokenMetrics.blockTimeLast.split('T')[0],
         key: dailyTokenMetrics.dateKey,
-        [dailyTokenMetrics.denom]: Number(dailyTokenMetrics.totalMintedProvidedLast) / 1_000_000,
+        [dailyTokenMetrics.denom]: Number(dailyTokenMetrics.totalMintedProvidedLast) / tokenDivisor,
       };
     });
   });
@@ -56,7 +58,7 @@ export const PSM = () => {
       <PageContent>
         <div className="grid gap-4 grid-cols-1 2xl:grid-cols-2">
           <div>
-            <PSMStats data={queryData} error={error} isLoading={isLoading} />
+            <PSMStats data={queryData} boardAuxes={boardAuxes} error={error} isLoading={isLoading} />
           </div>
           <PSMMintedPoolBalancePie data={queryData} isLoading={isLoading} />
         </div>

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -18,6 +18,12 @@ query {
             denom
         }
     }
+    boardAuxes {
+        nodes {
+            allegedName
+            decimalPlaces
+        }
+    }
 }`;
 
 export const PSM_GRAPH_TOKENS_QUERY = `

--- a/src/types/psm-types.ts
+++ b/src/types/psm-types.ts
@@ -22,3 +22,30 @@ export type PsmMetricsDailyResponse = {
   };
 };
 export type GraphData = { key: number; x: string };
+
+export type Metadata = {
+  lastProcessedHeight: number;
+};
+export type PsmMetricNode = {
+  blockHeight: string;
+  denom: string;
+  mintedPoolBalance: string;
+};
+
+export type PsmGovernanceNode = {
+  mintLimit: string;
+  denom: string;
+};
+
+export type BoardAuxesNode = { allegedName: string; decimalPlaces: number };
+
+export type PSMDashboardResponse = {
+  _metadata: Metadata;
+  psmMetrics: {
+    nodes: Array<PsmMetricNode>;
+  };
+  psmGovernances: {
+    nodes: Array<PsmGovernanceNode>;
+  };
+  boardAuxes: { nodes: Array<BoardAuxesNode> };
+};

--- a/src/widgets/PSMStats.tsx
+++ b/src/widgets/PSMStats.tsx
@@ -1,9 +1,19 @@
 import { PSMStats as Item, Skeleton } from '@/components/PSMStats';
 import { ErrorAlert } from '@/components/ErrorAlert';
 import { coinLabels } from '../coinLabels';
-import { range } from '@/utils';
+import { getTokenDivisor, range } from '@/utils';
 
-export function PSMStats({ data, error, isLoading }: { data: object; error?: Error; isLoading: boolean }) {
+export function PSMStats({
+  data,
+  error,
+  boardAuxes,
+  isLoading,
+}: {
+  data: object;
+  boardAuxes: { [key: string]: number };
+  error?: Error;
+  isLoading: boolean;
+}) {
   if (error) {
     return <ErrorAlert value={error} title="Request Error" />;
   }
@@ -21,8 +31,11 @@ export function PSMStats({ data, error, isLoading }: { data: object; error?: Err
   return (
     <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
       {Object.entries(data).map(([coinName, coinData]) => {
-        const formattedMintLimit = coinData.mintLimit / 1_000_000;
-        const formattedPoolBalance = coinData.mintedPoolBalance / 1_000_000;
+        const tokenDivisor = getTokenDivisor(boardAuxes, 'IST');
+
+        const formattedMintLimit = coinData.mintLimit / tokenDivisor;
+        const formattedPoolBalance = coinData.mintedPoolBalance / tokenDivisor;
+
         return (
           <Item
             data={{

--- a/tests/__mocks__/PSM.ts
+++ b/tests/__mocks__/PSM.ts
@@ -84,6 +84,58 @@ export const dashboardDataMock = {
           },
         ],
       },
+      boardAuxes: {
+        nodes: [
+          {
+            allegedName: 'USDC_axl',
+            decimalPlaces: 6,
+          },
+          {
+            allegedName: 'USDT_axl',
+            decimalPlaces: 6,
+          },
+          {
+            allegedName: 'IST',
+            decimalPlaces: 6,
+          },
+          {
+            allegedName: 'KREAdCHARACTER',
+            decimalPlaces: 0,
+          },
+          {
+            allegedName: 'DAI_grv',
+            decimalPlaces: 18,
+          },
+          {
+            allegedName: 'ATOM',
+            decimalPlaces: 6,
+          },
+          {
+            allegedName: 'USDT_grv',
+            decimalPlaces: 6,
+          },
+          {
+            allegedName: 'BLD',
+            decimalPlaces: 6,
+          },
+          {
+            allegedName: 'KREAdITEM',
+            decimalPlaces: 0,
+          },
+          {
+            allegedName: 'USDC_grv',
+            decimalPlaces: 6,
+          },
+          {
+            allegedName: 'Zoe Invitation',
+            decimalPlaces: 0,
+          },
+          {
+            allegedName: 'DAI_axl',
+            decimalPlaces: 18,
+          },
+        ],
+      },
     },
   },
 };

--- a/tests/__snapshots__/PSM.test.tsx.snap
+++ b/tests/__snapshots__/PSM.test.tsx.snap
@@ -39,13 +39,13 @@ exports[`PSM Dashboard Snapshot tests should match snapshot when data is loaded 
                   class="font-bold"
                   data-testid="psm-minted-ist-undefined"
                 >
-                  $2.38
+                  —
                    of
                    
                   <span
                     class="text-gray-400"
                   >
-                    $1.00M
+                    —
                   </span>
                 </span>
                 <p
@@ -60,7 +60,7 @@ exports[`PSM Dashboard Snapshot tests should match snapshot when data is loaded 
                 <span
                   class="font-bold"
                 >
-                  0%
+                  NaN%
                 </span>
                 <p
                   class="text-sm text-muted-foreground"

--- a/tests/__snapshots__/PSM.test.tsx.snap
+++ b/tests/__snapshots__/PSM.test.tsx.snap
@@ -39,13 +39,13 @@ exports[`PSM Dashboard Snapshot tests should match snapshot when data is loaded 
                   class="font-bold"
                   data-testid="psm-minted-ist-undefined"
                 >
-                  —
+                  $2.38
                    of
                    
                   <span
                     class="text-gray-400"
                   >
-                    —
+                    $1.00M
                   </span>
                 </span>
                 <p
@@ -60,7 +60,7 @@ exports[`PSM Dashboard Snapshot tests should match snapshot when data is loaded 
                 <span
                   class="font-bold"
                 >
-                  NaN%
+                  0%
                 </span>
                 <p
                   class="text-sm text-muted-foreground"


### PR DESCRIPTION
The PR does the following:
- Use `boardAuxes` to determine the divisor based on decimal places instead of hardcoding `1_000_000`.
- Ensure type safety and clarity by defining types properly.

NOTE: These changes are made on the PSM page. For testing, please visit `/psm` route. 