### PR TITLE
chore: use decimal places on reserve page

### DIFF
--- a/src/pages/Reserve.tsx
+++ b/src/pages/Reserve.tsx
@@ -79,7 +79,12 @@ export const Reserve = () => {
           />
           <ReserveShortfall data={reserveDashboardQueryData} boardAuxes={boardAuxes} isLoading={isLoading} />
         </div>
-        <ReserveHistoryGraph tokenNames={tokenNames} error={tokenNamesError} isLoading={tokenNamesIsLoading} />
+        <ReserveHistoryGraph
+          tokenNames={tokenNames}
+          boardAuxes={boardAuxes}
+          error={tokenNamesError}
+          isLoading={tokenNamesIsLoading}
+        />
       </PageContent>
     </>
   );

--- a/src/pages/Reserve.tsx
+++ b/src/pages/Reserve.tsx
@@ -23,6 +23,10 @@ export const Reserve = () => {
   const oraclePrices: { [key: string]: OraclePriceNode } =
     response?.oraclePrices?.nodes?.reduce((agg, node) => ({ ...agg, [node.typeInName]: node }), {}) || {};
 
+  const boardAuxes: { [key: string]: number } = response?.boardAuxes?.nodes?.reduce(
+    (agg, node) => ({ ...agg, [node.allegedName]: node.decimalPlaces }),
+    {},
+  );
   // TODO: make the fallback implementation in this section of code more readable
   const reserveDashboardQueryData: ReserveDashboardData =
     response?.reserveMetrics?.nodes?.map((vaultNode) => ({
@@ -66,9 +70,10 @@ export const Reserve = () => {
       <PageHeader title="Reserve Assets" />
       <PageContent>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <ReserveSummary data={reserveDashboardQueryData} isLoading={isLoading} />
+          <ReserveSummary data={reserveDashboardQueryData} boardAuxes={boardAuxes} isLoading={isLoading} />
           <ReserveCosmosSummary
             reserveAddress={reserveAddress}
+            boardAuxes={boardAuxes}
             isLoading={moduleAccountsLoading}
             error={moduleAccountsError}
           />

--- a/src/pages/Reserve.tsx
+++ b/src/pages/Reserve.tsx
@@ -77,7 +77,7 @@ export const Reserve = () => {
             isLoading={moduleAccountsLoading}
             error={moduleAccountsError}
           />
-          <ReserveShortfall data={reserveDashboardQueryData} isLoading={isLoading} />
+          <ReserveShortfall data={reserveDashboardQueryData} boardAuxes={boardAuxes} isLoading={isLoading} />
         </div>
         <ReserveHistoryGraph tokenNames={tokenNames} error={tokenNamesError} isLoading={tokenNamesIsLoading} />
       </PageContent>

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -164,6 +164,7 @@ query {
         nodes {
             typeInName
             typeOutAmount
+            typeInAmount
         }
     }
     boardAuxes {

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -166,6 +166,12 @@ query {
             typeOutAmount
         }
     }
+    boardAuxes {
+        nodes {
+            allegedName
+            decimalPlaces
+        }
+    }
 }`
 
 

--- a/src/types/reserve-types.ts
+++ b/src/types/reserve-types.ts
@@ -25,9 +25,11 @@ export type ReserveMetricsNode = {
   allocations: { nodes: Array<AllocationsNode> };
   shortfallBalance: number;
 };
+export type BoardAuxesNode = { allegedName: string; decimalPlaces: number };
 export type ReserveDashboardResponse = {
   oraclePrices: { nodes: Array<OraclePriceNode> };
   reserveMetrics: { nodes: Array<ReserveMetricsNode> };
+  boardAuxes: { nodes: Array<BoardAuxesNode> };
 };
 export type ReserveDashboardData = Array<{
   shortfallBalance: number;

--- a/src/widgets/LiquidatedVaults.tsx
+++ b/src/widgets/LiquidatedVaults.tsx
@@ -51,7 +51,7 @@ export function LiquidatedVaults({ title = 'Liquidated Vaults', data, boardAuxes
     const istDebtAmount = vaultData.liquidatingState.debt / istDivisor;
     const collateralAmount = vaultData.liquidatingState.balance / tokenDivisor;
     const liquidationPrice = (istDebtAmount * liquidationRatio) / collateralAmount;
-    const collateralAmountReturned = (vaultData.liquidatingState.balance - vaultData.balance) / 1_000_000;
+    const collateralAmountReturned = (vaultData.liquidatingState.balance - vaultData.balance) / tokenDivisor;
     const oraclePriceRatio =
       parseBigInt(vaultData.oraclePrice?.typeOutAmount) / parseBigInt(vaultData.oraclePrice?.typeInAmount);
     const collateralAmountReturnedUsd = collateralAmountReturned * oraclePriceRatio;

--- a/src/widgets/ReserveCosmosSummary.tsx
+++ b/src/widgets/ReserveCosmosSummary.tsx
@@ -1,6 +1,6 @@
 import { ValueCard } from '@/components/ValueCard';
 import { GET_ACCOUNT_BALANCE_URL, UIST_DENOMINATION } from '@/constants';
-import { fetchDataFromUrl, formatPrice } from '@/utils';
+import { fetchDataFromUrl, formatPrice, getTokenDivisor } from '@/utils';
 import { AxiosResponse, AxiosError } from 'axios';
 import useSWR from 'swr';
 import DataStatus from '@/components/DataStatus';
@@ -10,9 +10,16 @@ type Props = {
   isLoading: boolean;
   error: any;
   reserveAddress: string;
+  boardAuxes: { [key: string]: number };
 };
 
-export function ReserveCosmosSummary({ title = 'Cosmos Reserve', isLoading, reserveAddress, error }: Props) {
+export function ReserveCosmosSummary({
+  title = 'Cosmos Reserve',
+  boardAuxes,
+  isLoading,
+  reserveAddress,
+  error,
+}: Props) {
   if (isLoading || error || !reserveAddress) {
     const errorMessage = !reserveAddress && 'Oops! Unable to show Cosmos Reserve';
 
@@ -34,7 +41,9 @@ export function ReserveCosmosSummary({ title = 'Cosmos Reserve', isLoading, rese
   const istReserve: { amount: number } = reserveBalance?.data?.balances?.find(
     (balance: { denom: string }) => balance.denom === UIST_DENOMINATION,
   );
-  const istReserveBalance = (istReserve?.amount || 0) / 1_000_000;
+
+  const istDivisor = getTokenDivisor(boardAuxes, 'IST');
+  const istReserveBalance = (istReserve?.amount || 0) / istDivisor;
 
   return <ValueCard title={title} value={formatPrice(istReserveBalance)} />;
 }

--- a/src/widgets/ReserveShortfall.tsx
+++ b/src/widgets/ReserveShortfall.tsx
@@ -1,18 +1,20 @@
 import { Skeleton } from '@/components/ui/skeleton';
 import { ValueCard } from '@/components/ValueCard';
-import { formatPrice } from '@/utils';
+import { formatPrice, getTokenDivisor } from '@/utils';
 import { ReserveDashboardData } from '@/types/reserve-types';
 
 type Props = {
   title?: string;
   data: ReserveDashboardData;
   isLoading: boolean;
+  boardAuxes: { [key: string]: number };
 };
 
-export function ReserveShortfall({ title = 'Reserve Shortfall', data, isLoading }: Props) {
+export function ReserveShortfall({ title = 'Reserve Shortfall', data, boardAuxes, isLoading }: Props) {
   if (isLoading || !data) {
     return <ValueCard title={title} value={<Skeleton className="w-[100px] h-[32px] rounded-full" />} />;
   }
-  const shortfall = data.reduce((agg, node) => agg + Number(node.shortfallBalance), 0) / 1_000_000;
+  const istDivisor = getTokenDivisor(boardAuxes, 'IST');
+  const shortfall = data.reduce((agg, node) => agg + Number(node.shortfallBalance), 0) / istDivisor;
   return <ValueCard title={title} value={formatPrice(shortfall)} />;
 }

--- a/src/widgets/ReserveSummary.tsx
+++ b/src/widgets/ReserveSummary.tsx
@@ -20,7 +20,7 @@ export function ReserveSummary({ title = 'Total Reserve Assets', data, boardAuxe
       Object.values(node.allocations).reduce((agg_, node_) => {
         const tokenDivisor = getTokenDivisor(boardAuxes, node_.denom);
         const allocationInUsd =
-          ((Number(node_.value) / tokenDivisor) * Number(node_.typeOutAmount || tokenDivisor)) / tokenDivisor;
+          ((Number(node_.value) / tokenDivisor) * Number(node_.typeOutAmount || 1)) / Number(node_.typeInAmount || 1);
         return agg_ + allocationInUsd;
       }, 0),
     0,

--- a/src/widgets/ReserveSummary.tsx
+++ b/src/widgets/ReserveSummary.tsx
@@ -1,15 +1,16 @@
 import { Skeleton } from '@/components/ui/skeleton';
 import { ValueCard } from '@/components/ValueCard';
 import { ReserveDashboardData } from '@/types/reserve-types';
-import { formatPrice } from '@/utils';
+import { formatPrice, getTokenDivisor } from '@/utils';
 
 type Props = {
   title?: string;
   data: ReserveDashboardData;
+  boardAuxes: { [key: string]: number };
   isLoading: boolean;
 };
 
-export function ReserveSummary({ title = 'Total Reserve Assets', data, isLoading }: Props) {
+export function ReserveSummary({ title = 'Total Reserve Assets', data, boardAuxes, isLoading }: Props) {
   if (isLoading || !data) {
     return <ValueCard title={title} value={<Skeleton className="w-[100px] h-[32px] rounded-full" />} />;
   }
@@ -17,7 +18,9 @@ export function ReserveSummary({ title = 'Total Reserve Assets', data, isLoading
     (agg, node) =>
       agg +
       Object.values(node.allocations).reduce((agg_, node_) => {
-        const allocationInUsd = ((Number(node_.value) / 1_000_000) * Number(node_.typeOutAmount || 1_000_000)) / 1_000_000;
+        const tokenDivisor = getTokenDivisor(boardAuxes, node_.denom);
+        const allocationInUsd =
+          ((Number(node_.value) / tokenDivisor) * Number(node_.typeOutAmount || tokenDivisor)) / tokenDivisor;
         return agg_ + allocationInUsd;
       }, 0),
     0,

--- a/tests/Reserve/construct-graph.spec.ts
+++ b/tests/Reserve/construct-graph.spec.ts
@@ -9,8 +9,13 @@ import { ReserveAllocationMetricsDailyNode } from '@/types/reserve-types';
 
 describe('Tests for constructing graph', () => {
   // Tests for constructGraph
-  it('should return a list of graph data with length equal to GRAPH_DAYS when given valid tokenNames and dailyMetricsResponse', () => {
+  it('should return a list of graph data with length equal to GRAPH_DAYS when given valid tokenNames, dailyMetricsResponse, boardAuxes', () => {
     const result = constructGraph(tokenNames, dailyMetricsResponse, boardAuxes);
+    expect(result).toHaveLength(GRAPH_DAYS);
+  });
+
+  it('should return a list of graph data using default values when boardAuxes is undefined', () => {
+    const result = constructGraph(tokenNames, dailyMetricsResponse, undefined as any);
     expect(result).toHaveLength(GRAPH_DAYS);
   });
 

--- a/tests/Reserve/construct-graph.spec.ts
+++ b/tests/Reserve/construct-graph.spec.ts
@@ -4,27 +4,27 @@ import {
   updateGraphDataForToken,
 } from '@/components/ReserveHistoryGraph';
 import { GRAPH_DAYS } from '@/constants';
-import { tokenNames, dailyMetricsResponse } from './mocks';
+import { tokenNames, dailyMetricsResponse, boardAuxes } from './mocks';
 import { ReserveAllocationMetricsDailyNode } from '@/types/reserve-types';
 
 describe('Tests for constructing graph', () => {
   // Tests for constructGraph
   it('should return a list of graph data with length equal to GRAPH_DAYS when given valid tokenNames and dailyMetricsResponse', () => {
-    const result = constructGraph(tokenNames, dailyMetricsResponse);
+    const result = constructGraph(tokenNames, dailyMetricsResponse, boardAuxes);
     expect(result).toHaveLength(GRAPH_DAYS);
   });
 
   it('should return an empty list when given empty tokenNames and dailyMetricsResponse', () => {
     const dailyMetricsResponse = {};
-    const result = constructGraph([], dailyMetricsResponse);
+    const result = constructGraph([], dailyMetricsResponse, boardAuxes);
     expect(result).toHaveLength(0);
   });
 
-  it('should return an empty list when given tokenNames and dailyMetricsResponse are null or undefined', () => {
-    let result = constructGraph(null as any, null);
+  it('should return an empty list when given tokenNames, dailyMetricsResponse and boardAuxes object is null or undefined', () => {
+    let result = constructGraph(null as any, null, null as any);
     expect(result).toHaveLength(0);
 
-    result = constructGraph(undefined as any, undefined);
+    result = constructGraph(undefined as any, undefined, undefined as any);
     expect(result).toHaveLength(0);
   });
 
@@ -53,7 +53,7 @@ describe('Tests for constructing graph', () => {
 
     let lastTokenMetric: ReserveAllocationMetricsDailyNode = dailyMetricsResponse?.[`${tokenName}_last`]?.nodes[0];
 
-    updateGraphDataForToken(tokenName, graphData, dailyMetricsResponse, lastTokenMetric);
+    updateGraphDataForToken(tokenName, graphData, dailyMetricsResponse, lastTokenMetric, boardAuxes);
 
     expect(graphData).toEqual({
       '20220101': { key: 1, x: '2022-01-01', ATOM: 85.9552681344 },
@@ -68,7 +68,7 @@ describe('Tests for constructing graph', () => {
 
     let lastTokenMetric: ReserveAllocationMetricsDailyNode = dailyMetricsResponse?.[`${tokenName}_last`]?.nodes[0];
 
-    updateGraphDataForToken(tokenName, graphData, dailyMetricsResponse, lastTokenMetric);
+    updateGraphDataForToken(tokenName, graphData, dailyMetricsResponse, lastTokenMetric, boardAuxes);
 
     expect(graphData).toEqual({
       '20220103': { key: 3, x: '2022-01-03', ATOM: 6.58702 },
@@ -83,7 +83,7 @@ describe('Tests for constructing graph', () => {
 
     let lastTokenMetric: ReserveAllocationMetricsDailyNode = dailyMetricsResponse?.[`${tokenName}_last`]?.nodes[0];
 
-    updateGraphDataForToken(tokenName, graphData, undefined, lastTokenMetric);
+    updateGraphDataForToken(tokenName, graphData, undefined, lastTokenMetric, boardAuxes);
 
     expect(graphData).toEqual({
       '20220103': { key: 3, x: '2022-01-03', ATOM: 6.58702 },

--- a/tests/Reserve/mocks.ts
+++ b/tests/Reserve/mocks.ts
@@ -1,3 +1,5 @@
+import { BoardAuxesMap } from '@/types/vault-types';
+
 export const tokenNames: string[] = ['ATOM', 'stTIA', 'stkATOM', 'stOSMO', 'stATOM'];
 export const dailyMetricsResponse = {
   ATOM: {
@@ -79,4 +81,19 @@ export const dailyMetricsResponse = {
       },
     ],
   },
+};
+
+export const boardAuxes: BoardAuxesMap = {
+  ATOM: 6,
+  BLD: 6,
+  DAI_axl: 18,
+  DAI_grv: 18,
+  IST: 6,
+  KREAdCHARACTER: 0,
+  KREAdITEM: 0,
+  USDC_axl: 6,
+  USDC_grv: 6,
+  USDT_axl: 6,
+  USDT_grv: 6,
+  'Zoe Invitation': 0,
 };

--- a/tests/__mocks__/Reserve.ts
+++ b/tests/__mocks__/Reserve.ts
@@ -76,6 +76,58 @@ export const dashboardDataMock = {
           },
         ],
       },
+      boardAuxes: {
+        nodes: [
+          {
+            allegedName: 'USDC_axl',
+            decimalPlaces: 6,
+          },
+          {
+            allegedName: 'USDT_axl',
+            decimalPlaces: 6,
+          },
+          {
+            allegedName: 'IST',
+            decimalPlaces: 6,
+          },
+          {
+            allegedName: 'KREAdCHARACTER',
+            decimalPlaces: 0,
+          },
+          {
+            allegedName: 'DAI_grv',
+            decimalPlaces: 18,
+          },
+          {
+            allegedName: 'ATOM',
+            decimalPlaces: 6,
+          },
+          {
+            allegedName: 'USDT_grv',
+            decimalPlaces: 6,
+          },
+          {
+            allegedName: 'BLD',
+            decimalPlaces: 6,
+          },
+          {
+            allegedName: 'KREAdITEM',
+            decimalPlaces: 0,
+          },
+          {
+            allegedName: 'USDC_grv',
+            decimalPlaces: 6,
+          },
+          {
+            allegedName: 'Zoe Invitation',
+            decimalPlaces: 0,
+          },
+          {
+            allegedName: 'DAI_axl',
+            decimalPlaces: 18,
+          },
+        ],
+      },
     },
   },
 };

--- a/tests/__snapshots__/Reserve.test.tsx.snap
+++ b/tests/__snapshots__/Reserve.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`Reserve Dashboard Snapshot tests should match snapshot when data is loa
           <div
             class="text-2xl font-bold"
           >
-            $1.25K
+            —
           </div>
         </div>
       </div>
@@ -53,7 +53,7 @@ exports[`Reserve Dashboard Snapshot tests should match snapshot when data is loa
           <div
             class="text-2xl font-bold"
           >
-            $33.35K
+            —
           </div>
         </div>
       </div>
@@ -75,7 +75,7 @@ exports[`Reserve Dashboard Snapshot tests should match snapshot when data is loa
           <div
             class="text-2xl font-bold"
           >
-            $7.84K
+            —
           </div>
         </div>
       </div>

--- a/tests/__snapshots__/Reserve.test.tsx.snap
+++ b/tests/__snapshots__/Reserve.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`Reserve Dashboard Snapshot tests should match snapshot when data is loa
           <div
             class="text-2xl font-bold"
           >
-            —
+            $1.25K
           </div>
         </div>
       </div>
@@ -53,7 +53,7 @@ exports[`Reserve Dashboard Snapshot tests should match snapshot when data is loa
           <div
             class="text-2xl font-bold"
           >
-            —
+            $33.35K
           </div>
         </div>
       </div>
@@ -75,7 +75,7 @@ exports[`Reserve Dashboard Snapshot tests should match snapshot when data is loa
           <div
             class="text-2xl font-bold"
           >
-            —
+            $7.84K
           </div>
         </div>
       </div>


### PR DESCRIPTION
The PR does the following:

- Use boardAuxes to determine the divisor based on decimal places instead of hardcoding `1_000_000`.

NOTE: These changes are made on the Reserve page. For testing, please visit `/reserve` route.