### PR TITLE
chore: use decimal places on liquidation page

### DIFF
--- a/src/pages/Liquidated.tsx
+++ b/src/pages/Liquidated.tsx
@@ -24,6 +24,11 @@ export function Liquidated() {
   );
   const response: LiquidationDashboardResponse = data?.data?.data;
 
+  const boardAuxes: { [key: string]: number } = response?.boardAuxes?.nodes?.reduce(
+    (agg, node) => ({ ...agg, [node.allegedName]: node.decimalPlaces }),
+    {},
+  );
+
   const liquidationDashboardData = {
     vaultLiquidations: response?.vaultLiquidations?.nodes,
   };
@@ -37,7 +42,7 @@ export function Liquidated() {
     LIQUIDATION_DAILY_METRICS_QUERY(tokenNames),
     subQueryFetcher,
   );
-  const dailyMetricsResponse: LiquidationMetricsDailyResponse = dailyMetricsData?.data.data;
+  const dailyMetricsResponse: LiquidationMetricsDailyResponse = dailyMetricsData?.data?.data;
   const graphDataMap: { [key: number]: GraphData } = {};
   Object.values(dailyMetricsResponse || {}).forEach((tokenDataList) => {
     tokenDataList?.nodes.forEach((dailyTokenMetrics) => {
@@ -74,7 +79,7 @@ export function Liquidated() {
         </ValueCardGrid>
         {/* <VaultStatesChart data={summedGraphDataList} isLoading={graphDataIsLoading} /> */}
         <hr className="my-5" />
-        <LiquidatedVaults data={liquidationDashboardData} isLoading={isLoading} />
+        <LiquidatedVaults data={liquidationDashboardData} boardAuxes={boardAuxes} isLoading={isLoading} />
       </PageContent>
     </>
   );

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -282,6 +282,12 @@ query {
 
 export const LIQUIDATIONS_DASHBOARD = `
 query {
+    boardAuxes {
+        nodes {
+            allegedName
+            decimalPlaces
+        }
+    }
     vaultManagerMetrics {
         nodes {
             id

--- a/src/types/liquidation-types.ts
+++ b/src/types/liquidation-types.ts
@@ -51,6 +51,7 @@ export type OraclePriceNode = {
   priceFeedName?: string;
 };
 
+export type BoardAuxesNode = { allegedName: string; decimalPlaces: number };
 export type LiquidationDashboardResponse = {
   vaultLiquidations: { nodes: Array<VaultLiquidationsNode> };
   vaultManagerGovernances: {
@@ -60,6 +61,7 @@ export type LiquidationDashboardResponse = {
     nodes: Array<VaultManagerMetricsNode>;
   };
   oraclePrices: { nodes: Array<OraclePriceNode> };
+  boardAuxes: { nodes: Array<BoardAuxesNode> };
 };
 export type LiquidationDashboardData = {
   vaultLiquidations: Array<VaultLiquidationsNode>;

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -251,6 +251,7 @@ export function createNumberWithLeadingZeroes(numOfZeroes: number) {
 
 export const parseBigInt = (str: string) => Number(str.slice(0, -1));
 
+
 /**
  * The function computes the token divisor for a given token name.
  *

--- a/src/widgets/LiquidatedVaults.tsx
+++ b/src/widgets/LiquidatedVaults.tsx
@@ -2,7 +2,7 @@ import { format, differenceInSeconds } from 'date-fns';
 import { Skeleton } from '@/components/ui/skeleton';
 import { LiquidatedVaultsTable } from '@/components/LiquidatedVaultsTable';
 import { SectionHeader } from '@/components/SectionHeader';
-import { formatSecondsToHumanReadable, parseBigInt } from '@/utils';
+import { formatSecondsToHumanReadable, getTokenDivisor, parseBigInt } from '@/utils';
 import { VAULT_STATES } from '@/constants';
 import { LiquidationDashboardData } from '@/types/liquidation-types';
 
@@ -10,9 +10,10 @@ type Props = {
   title?: string;
   data: LiquidationDashboardData;
   isLoading: boolean;
+  boardAuxes: { [key: string]: number };
 };
 
-export function LiquidatedVaults({ title = 'Liquidated Vaults', data, isLoading }: Props) {
+export function LiquidatedVaults({ title = 'Liquidated Vaults', data, boardAuxes, isLoading }: Props) {
   if (isLoading || !data) {
     return (
       <>
@@ -43,8 +44,12 @@ export function LiquidatedVaults({ title = 'Liquidated Vaults', data, isLoading 
     const liquidationRatio =
       parseBigInt(vaultData.vaultManagerGovernance?.liquidationMarginNumerator) /
       parseBigInt(vaultData.vaultManagerGovernance?.liquidationMarginDenominator);
-    const istDebtAmount = vaultData.liquidatingState.debt / 1_000_000;
-    const collateralAmount = vaultData.liquidatingState.balance / 1_000_000;
+
+    const istDivisor = getTokenDivisor(boardAuxes, 'IST');
+    const tokenDivisor = getTokenDivisor(boardAuxes, vaultData.denom);
+
+    const istDebtAmount = vaultData.liquidatingState.debt / istDivisor;
+    const collateralAmount = vaultData.liquidatingState.balance / tokenDivisor;
     const liquidationPrice = (istDebtAmount * liquidationRatio) / collateralAmount;
     const collateralAmountReturned = (vaultData.liquidatingState.balance - vaultData.balance) / 1_000_000;
     const oraclePriceRatio =

--- a/tests/__mocks__/Liquidated.ts
+++ b/tests/__mocks__/Liquidated.ts
@@ -212,6 +212,58 @@ export const dashboardDataMock = {
           },
         ],
       },
+      boardAuxes: {
+        nodes: [
+          {
+            allegedName: 'USDC_axl',
+            decimalPlaces: 6,
+          },
+          {
+            allegedName: 'USDT_axl',
+            decimalPlaces: 6,
+          },
+          {
+            allegedName: 'IST',
+            decimalPlaces: 6,
+          },
+          {
+            allegedName: 'KREAdCHARACTER',
+            decimalPlaces: 0,
+          },
+          {
+            allegedName: 'DAI_grv',
+            decimalPlaces: 18,
+          },
+          {
+            allegedName: 'ATOM',
+            decimalPlaces: 6,
+          },
+          {
+            allegedName: 'USDT_grv',
+            decimalPlaces: 6,
+          },
+          {
+            allegedName: 'BLD',
+            decimalPlaces: 6,
+          },
+          {
+            allegedName: 'KREAdITEM',
+            decimalPlaces: 0,
+          },
+          {
+            allegedName: 'USDC_grv',
+            decimalPlaces: 6,
+          },
+          {
+            allegedName: 'Zoe Invitation',
+            decimalPlaces: 0,
+          },
+          {
+            allegedName: 'DAI_axl',
+            decimalPlaces: 18,
+          },
+        ],
+      },
     },
   },
 };


### PR DESCRIPTION
The PR does the following:

- Use boardAuxes to determine the divisor based on decimal places instead of hardcoding `1_000_000`.

NOTE: These changes are made on the Liquidations page. For testing, please visit `/liquidated` route.