### PR TITLE
test: freeze time for snapshot

### DIFF
--- a/tests/Reserve.test.tsx
+++ b/tests/Reserve.test.tsx
@@ -22,6 +22,7 @@ global.ResizeObserver = jest.fn().mockImplementation(() => ({
   unobserve: jest.fn(),
   disconnect: jest.fn(),
 }));
+jest.useFakeTimers().setSystemTime(new Date('2024-06-07'));
 
 jest.mock('recharts', () => {
   const OriginalModule = jest.requireActual('recharts');


### PR DESCRIPTION
this PR updates the snapshot tests in `tests/Reserve.test.tsx`
It mocks the `Date` object in js so that `new Date.now()` always returns the same date during testing snapshots 