### PR TITLE
fix: show liquidation graph again 

### DIFF
--- a/src/components/LiquidatedVaultsTable.tsx
+++ b/src/components/LiquidatedVaultsTable.tsx
@@ -50,26 +50,26 @@ export const columns: DataColumn<Row>[] = [
     type: 'number',
     header: 'IST Debt Amount',
   },
-  // {
-  //   accessorKey: 'liquidation_margin_avg',
-  //   type: 'percent',
-  //   header: 'Liquidation Ratio',
-  // },
-  // {
-  //   accessorKey: 'liquidating_rate',
-  //   type: 'usd',
-  //   header: 'Liquidation Price',
-  // },
+  {
+    accessorKey: 'liquidation_margin_avg',
+    type: 'percent',
+    header: 'Liquidation Ratio',
+  },
+  {
+    accessorKey: 'liquidating_rate',
+    type: 'usd',
+    header: 'Liquidation Price',
+  },
   {
     accessorKey: 'liquidated_return_amount',
     type: 'number',
     header: 'Collateral Returned Amount',
   },
-  // {
-  //   accessorKey: 'liquidated_return_amount_usd',
-  //   type: 'usd',
-  //   header: 'Collateral Returned ($USD)',
-  // },
+  {
+    accessorKey: 'liquidated_return_amount_usd',
+    type: 'usd',
+    header: 'Collateral Returned ($USD)',
+  },
 ];
 
 export function LiquidatedVaultsTable({ data }: Props) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,7 +11,6 @@ export const VBANK_RESERVE_ACCOUNT = 'vbank/reserve';
 export const GRAPH_DAYS = 90;
 
 export const SUBQUERY_URL = 'https://api.subquery.network/sq/agoric-labs/agoric-mainnet-v2';
-export const SUBQUERY_STAGING_URL = 'https://api.subquery.network/sq/agoric-labs/agoric-mainnet-v2__YWdvc';
 
 export const enum VAULT_STATES {
   ACTIVE = 'active',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,7 +11,7 @@ export const VBANK_RESERVE_ACCOUNT = 'vbank/reserve';
 export const GRAPH_DAYS = 90;
 
 export const SUBQUERY_URL = 'https://api.subquery.network/sq/agoric-labs/agoric-mainnet-v2';
-export const SUBQUERY_STAGING_URL = 'https://api.subquery.network/sq/agoric-labs/agoric-mainnet-v2';
+export const SUBQUERY_STAGING_URL = 'https://api.subquery.network/sq/agoric-labs/agoric-mainnet-v2__YWdvc';
 
 export const enum VAULT_STATES {
   ACTIVE = 'active',

--- a/src/pages/Liquidated.tsx
+++ b/src/pages/Liquidated.tsx
@@ -14,7 +14,7 @@ import { ErrorAlert } from '@/components/ErrorAlert';
 
 export function Liquidated() {
   const { data, isLoading, error } = useSWR<AxiosResponse, AxiosError>(LIQUIDATIONS_DASHBOARD, (query: string) =>
-    subQueryFetcher(query),
+    subQueryFetcher(query, SUBQUERY_STAGING_URL),
   );
   const response: LiquidationDashboardResponse = data?.data?.data;
 
@@ -28,28 +28,28 @@ export function Liquidated() {
   };
 
   //  Queries for graph
-  // const {
-  //   data: vaultStateDailyData,
-  //   isLoading: graphDataIsLoading,
-  //   error: graphDataError,
-  // } = useSWR<AxiosResponse, AxiosError>(VAULT_STATE_DAILIES_QUERY, (query: string) =>
-  //   subQueryFetcher(query, SUBQUERY_STAGING_URL),
-  // );
-  // const vaultStateDailyResponse: VaultStateDailyResponse = vaultStateDailyData?.data?.data;
-  // const graphDataMap: { [key: number]: GraphData } = {};
-  // vaultStateDailyResponse?.vaultStatesDailies.nodes?.forEach((vaultState) => {
-  //   graphDataMap[Number(vaultState.id)] = {
-  //     x: vaultState.blockTimeLast?.split('T')[0],
-  //     key: Number(vaultState.id),
-  //     active: Number(vaultState.active),
-  //     liquidated: Number(vaultState.liquidated) + Number(vaultState.liquidatedClosed),
-  //     closed: Number(vaultState.closed),
-  //   };
-  // });
+  const {
+    data: vaultStateDailyData,
+    isLoading: graphDataIsLoading,
+    error: graphDataError,
+  } = useSWR<AxiosResponse, AxiosError>(VAULT_STATE_DAILIES_QUERY, (query: string) =>
+    subQueryFetcher(query, SUBQUERY_STAGING_URL),
+  );
+  const vaultStateDailyResponse: VaultStateDailyResponse = vaultStateDailyData?.data?.data;
+  const graphDataMap: { [key: number]: GraphData } = {};
+  vaultStateDailyResponse?.vaultStatesDailies.nodes?.forEach((vaultState) => {
+    graphDataMap[Number(vaultState.id)] = {
+      x: vaultState.blockTimeLast?.split('T')[0],
+      key: Number(vaultState.id),
+      active: Number(vaultState.active),
+      liquidated: Number(vaultState.liquidated) + Number(vaultState.liquidatedClosed),
+      closed: Number(vaultState.closed),
+    };
+  });
 
-  // const graphDataList = populateMissingDays(graphDataMap, GRAPH_DAYS);
+  const graphDataList = populateMissingDays(graphDataMap, GRAPH_DAYS);
 
-  const errorMessage = error;
+  const errorMessage = error || graphDataError;
   if (errorMessage) {
     return <ErrorAlert value={errorMessage} title="Request Error" />;
   }
@@ -61,7 +61,7 @@ export function Liquidated() {
         <ValueCardGrid>
           <LiquidatedVaultCountCard data={response?.vaultManagerMetrics?.nodes} isLoading={isLoading} />
         </ValueCardGrid>
-        {/* <VaultStatesChart data={graphDataList} isLoading={graphDataIsLoading} /> */}
+        <VaultStatesChart data={graphDataList} isLoading={graphDataIsLoading} />
         <hr className="my-5" />
         <LiquidatedVaults data={liquidationDashboardData} boardAuxes={boardAuxes} isLoading={isLoading} />
       </PageContent>

--- a/src/pages/Liquidated.tsx
+++ b/src/pages/Liquidated.tsx
@@ -9,13 +9,11 @@ import { VaultStatesChart } from '@/widgets/VaultStatesChart';
 import { populateMissingDays, subQueryFetcher } from '@/utils';
 import { LIQUIDATIONS_DASHBOARD, VAULT_STATE_DAILIES_QUERY } from '@/queries';
 import { GraphData, LiquidationDashboardResponse, VaultStateDailyResponse } from '@/types/liquidation-types';
-import { GRAPH_DAYS, SUBQUERY_STAGING_URL } from '@/constants';
+import { GRAPH_DAYS } from '@/constants';
 import { ErrorAlert } from '@/components/ErrorAlert';
 
 export function Liquidated() {
-  const { data, isLoading, error } = useSWR<AxiosResponse, AxiosError>(LIQUIDATIONS_DASHBOARD, (query: string) =>
-    subQueryFetcher(query, SUBQUERY_STAGING_URL),
-  );
+  const { data, isLoading, error } = useSWR<AxiosResponse, AxiosError>(LIQUIDATIONS_DASHBOARD, subQueryFetcher);
   const response: LiquidationDashboardResponse = data?.data?.data;
 
   const boardAuxes: { [key: string]: number } = response?.boardAuxes?.nodes?.reduce(
@@ -32,9 +30,7 @@ export function Liquidated() {
     data: vaultStateDailyData,
     isLoading: graphDataIsLoading,
     error: graphDataError,
-  } = useSWR<AxiosResponse, AxiosError>(VAULT_STATE_DAILIES_QUERY, (query: string) =>
-    subQueryFetcher(query, SUBQUERY_STAGING_URL),
-  );
+  } = useSWR<AxiosResponse, AxiosError>(VAULT_STATE_DAILIES_QUERY, subQueryFetcher);
   const vaultStateDailyResponse: VaultStateDailyResponse = vaultStateDailyData?.data?.data;
   const graphDataMap: { [key: number]: GraphData } = {};
   vaultStateDailyResponse?.vaultStatesDailies.nodes?.forEach((vaultState) => {

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -314,6 +314,8 @@ query {
             state
             balance
             blockTime
+            oraclePrice
+            vaultManagerGovernance
             currentState {
                 id
                 denom

--- a/tests/__snapshots__/Liquidated.test.tsx.snap
+++ b/tests/__snapshots__/Liquidated.test.tsx.snap
@@ -36,6 +36,5947 @@ exports[`Liquidation Dashboard Snapshot tests should match snapshot when data is
         </div>
       </div>
     </div>
+    <div
+      class="rounded-lg border bg-card text-card-foreground shadow-sm my-4 mb-4"
+    >
+      <div
+        class="flex flex-col space-y-1.5 p-6"
+      >
+        <h3
+          class="text-2xl font-semibold leading-none tracking-tight"
+        >
+          Vault States
+        </h3>
+      </div>
+      <div
+        class="p-6 pt-0"
+      >
+        <div
+          class="recharts-responsive-container"
+          style="width: 800px; height: 800px; min-width: 0;"
+        >
+          <div
+            class="recharts-wrapper"
+            role="region"
+            style="position: relative; cursor: default; width: 800px; height: 800px;"
+          >
+            <svg
+              class="recharts-surface"
+              height="800"
+              viewBox="0 0 800 800"
+              width="800"
+            >
+              <title />
+              <desc />
+              <defs>
+                <clippath
+                  id="recharts1-clip"
+                >
+                  <rect
+                    height="745"
+                    width="690"
+                    x="80"
+                    y="20"
+                  />
+                </clippath>
+              </defs>
+              <g
+                class="recharts-cartesian-grid"
+              >
+                <g
+                  class="recharts-cartesian-grid-horizontal"
+                >
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="80"
+                    x2="770"
+                    y="20"
+                    y1="765"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="80"
+                    x2="770"
+                    y="20"
+                    y1="578.75"
+                    y2="578.75"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="80"
+                    x2="770"
+                    y="20"
+                    y1="392.5"
+                    y2="392.5"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="80"
+                    x2="770"
+                    y="20"
+                    y1="206.25"
+                    y2="206.25"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="80"
+                    x2="770"
+                    y="20"
+                    y1="20"
+                    y2="20"
+                  />
+                </g>
+                <g
+                  class="recharts-cartesian-grid-vertical"
+                >
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="83.83333333333333"
+                    x2="83.83333333333333"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="91.5"
+                    x2="91.5"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="99.16666666666666"
+                    x2="99.16666666666666"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="106.83333333333333"
+                    x2="106.83333333333333"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="114.5"
+                    x2="114.5"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="122.16666666666667"
+                    x2="122.16666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="129.83333333333334"
+                    x2="129.83333333333334"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="137.50000000000003"
+                    x2="137.50000000000003"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="145.16666666666669"
+                    x2="145.16666666666669"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="152.83333333333334"
+                    x2="152.83333333333334"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="160.50000000000003"
+                    x2="160.50000000000003"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="168.16666666666669"
+                    x2="168.16666666666669"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="175.83333333333334"
+                    x2="175.83333333333334"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="183.50000000000003"
+                    x2="183.50000000000003"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="191.16666666666669"
+                    x2="191.16666666666669"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="198.83333333333334"
+                    x2="198.83333333333334"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="206.50000000000003"
+                    x2="206.50000000000003"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="214.16666666666669"
+                    x2="214.16666666666669"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="221.83333333333334"
+                    x2="221.83333333333334"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="229.50000000000003"
+                    x2="229.50000000000003"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="237.16666666666669"
+                    x2="237.16666666666669"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="244.83333333333334"
+                    x2="244.83333333333334"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="252.50000000000003"
+                    x2="252.50000000000003"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="260.1666666666667"
+                    x2="260.1666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="267.8333333333333"
+                    x2="267.8333333333333"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="275.5"
+                    x2="275.5"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="283.1666666666667"
+                    x2="283.1666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="290.8333333333333"
+                    x2="290.8333333333333"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="298.5"
+                    x2="298.5"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="306.1666666666667"
+                    x2="306.1666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="313.8333333333333"
+                    x2="313.8333333333333"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="321.5"
+                    x2="321.5"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="329.1666666666667"
+                    x2="329.1666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="336.8333333333333"
+                    x2="336.8333333333333"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="344.5"
+                    x2="344.5"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="352.1666666666667"
+                    x2="352.1666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="359.8333333333333"
+                    x2="359.8333333333333"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="367.5"
+                    x2="367.5"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="375.1666666666667"
+                    x2="375.1666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="382.8333333333333"
+                    x2="382.8333333333333"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="390.5"
+                    x2="390.5"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="398.1666666666667"
+                    x2="398.1666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="405.8333333333333"
+                    x2="405.8333333333333"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="413.5"
+                    x2="413.5"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="421.1666666666667"
+                    x2="421.1666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="428.8333333333333"
+                    x2="428.8333333333333"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="436.5"
+                    x2="436.5"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="444.1666666666667"
+                    x2="444.1666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="451.8333333333333"
+                    x2="451.8333333333333"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="459.5"
+                    x2="459.5"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="467.1666666666667"
+                    x2="467.1666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="474.8333333333333"
+                    x2="474.8333333333333"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="482.5"
+                    x2="482.5"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="490.1666666666667"
+                    x2="490.1666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="497.8333333333333"
+                    x2="497.8333333333333"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="505.5"
+                    x2="505.5"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="513.1666666666667"
+                    x2="513.1666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="520.8333333333334"
+                    x2="520.8333333333334"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="528.5000000000001"
+                    x2="528.5000000000001"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="536.1666666666667"
+                    x2="536.1666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="543.8333333333334"
+                    x2="543.8333333333334"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="551.5000000000001"
+                    x2="551.5000000000001"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="559.1666666666667"
+                    x2="559.1666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="566.8333333333334"
+                    x2="566.8333333333334"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="574.5000000000001"
+                    x2="574.5000000000001"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="582.1666666666667"
+                    x2="582.1666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="589.8333333333334"
+                    x2="589.8333333333334"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="597.5000000000001"
+                    x2="597.5000000000001"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="605.1666666666667"
+                    x2="605.1666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="612.8333333333334"
+                    x2="612.8333333333334"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="620.5000000000001"
+                    x2="620.5000000000001"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="628.1666666666667"
+                    x2="628.1666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="635.8333333333334"
+                    x2="635.8333333333334"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="643.5000000000001"
+                    x2="643.5000000000001"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="651.1666666666667"
+                    x2="651.1666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="658.8333333333334"
+                    x2="658.8333333333334"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="666.5000000000001"
+                    x2="666.5000000000001"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="674.1666666666667"
+                    x2="674.1666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="681.8333333333334"
+                    x2="681.8333333333334"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="689.5000000000001"
+                    x2="689.5000000000001"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="697.1666666666667"
+                    x2="697.1666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="704.8333333333334"
+                    x2="704.8333333333334"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="712.5000000000001"
+                    x2="712.5000000000001"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="720.1666666666667"
+                    x2="720.1666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="727.8333333333334"
+                    x2="727.8333333333334"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="735.5000000000001"
+                    x2="735.5000000000001"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="743.1666666666667"
+                    x2="743.1666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="750.8333333333334"
+                    x2="750.8333333333334"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="758.5000000000001"
+                    x2="758.5000000000001"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="766.1666666666667"
+                    x2="766.1666666666667"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="80"
+                    x2="80"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                  <line
+                    fill="none"
+                    height="745"
+                    stroke="#ccc"
+                    stroke-dasharray="3 3"
+                    width="690"
+                    x="80"
+                    x1="770"
+                    x2="770"
+                    y="20"
+                    y1="20"
+                    y2="765"
+                  />
+                </g>
+              </g>
+              <g
+                class="recharts-layer recharts-cartesian-axis recharts-xAxis xAxis"
+              >
+                <line
+                  class="recharts-cartesian-axis-line"
+                  fill="none"
+                  height="30"
+                  orientation="bottom"
+                  stroke="#666"
+                  width="690"
+                  x="80"
+                  x1="80"
+                  x2="770"
+                  y="765"
+                  y1="765"
+                  y2="765"
+                />
+                <g
+                  class="recharts-cartesian-axis-ticks"
+                >
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="83.83333333333333"
+                      x2="83.83333333333333"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="83.83333333333333"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="83.83333333333333"
+                      >
+                        03/08
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="91.5"
+                      x2="91.5"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="91.5"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="91.5"
+                      >
+                        03/09
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="99.16666666666666"
+                      x2="99.16666666666666"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="99.16666666666666"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="99.16666666666666"
+                      >
+                        03/10
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="106.83333333333333"
+                      x2="106.83333333333333"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="106.83333333333333"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="106.83333333333333"
+                      >
+                        03/11
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="114.5"
+                      x2="114.5"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="114.5"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="114.5"
+                      >
+                        03/12
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="122.16666666666667"
+                      x2="122.16666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="122.16666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="122.16666666666667"
+                      >
+                        03/13
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="129.83333333333334"
+                      x2="129.83333333333334"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="129.83333333333334"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="129.83333333333334"
+                      >
+                        03/14
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="137.50000000000003"
+                      x2="137.50000000000003"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="137.50000000000003"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="137.50000000000003"
+                      >
+                        03/15
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="145.16666666666669"
+                      x2="145.16666666666669"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="145.16666666666669"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="145.16666666666669"
+                      >
+                        03/16
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="152.83333333333334"
+                      x2="152.83333333333334"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="152.83333333333334"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="152.83333333333334"
+                      >
+                        03/17
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="160.50000000000003"
+                      x2="160.50000000000003"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="160.50000000000003"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="160.50000000000003"
+                      >
+                        03/18
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="168.16666666666669"
+                      x2="168.16666666666669"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="168.16666666666669"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="168.16666666666669"
+                      >
+                        03/19
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="175.83333333333334"
+                      x2="175.83333333333334"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="175.83333333333334"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="175.83333333333334"
+                      >
+                        03/20
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="183.50000000000003"
+                      x2="183.50000000000003"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="183.50000000000003"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="183.50000000000003"
+                      >
+                        03/21
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="191.16666666666669"
+                      x2="191.16666666666669"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="191.16666666666669"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="191.16666666666669"
+                      >
+                        03/22
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="198.83333333333334"
+                      x2="198.83333333333334"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="198.83333333333334"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="198.83333333333334"
+                      >
+                        03/23
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="206.50000000000003"
+                      x2="206.50000000000003"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="206.50000000000003"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="206.50000000000003"
+                      >
+                        03/24
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="214.16666666666669"
+                      x2="214.16666666666669"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="214.16666666666669"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="214.16666666666669"
+                      >
+                        03/25
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="221.83333333333334"
+                      x2="221.83333333333334"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="221.83333333333334"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="221.83333333333334"
+                      >
+                        03/26
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="229.50000000000003"
+                      x2="229.50000000000003"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="229.50000000000003"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="229.50000000000003"
+                      >
+                        03/27
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="237.16666666666669"
+                      x2="237.16666666666669"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="237.16666666666669"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="237.16666666666669"
+                      >
+                        03/28
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="244.83333333333334"
+                      x2="244.83333333333334"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="244.83333333333334"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="244.83333333333334"
+                      >
+                        03/29
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="252.50000000000003"
+                      x2="252.50000000000003"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="252.50000000000003"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="252.50000000000003"
+                      >
+                        03/30
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="260.1666666666667"
+                      x2="260.1666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="260.1666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="260.1666666666667"
+                      >
+                        03/31
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="267.8333333333333"
+                      x2="267.8333333333333"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="267.8333333333333"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="267.8333333333333"
+                      >
+                        04/01
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="275.5"
+                      x2="275.5"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="275.5"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="275.5"
+                      >
+                        04/02
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="283.1666666666667"
+                      x2="283.1666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="283.1666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="283.1666666666667"
+                      >
+                        04/03
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="290.8333333333333"
+                      x2="290.8333333333333"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="290.8333333333333"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="290.8333333333333"
+                      >
+                        04/04
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="298.5"
+                      x2="298.5"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="298.5"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="298.5"
+                      >
+                        04/05
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="306.1666666666667"
+                      x2="306.1666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="306.1666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="306.1666666666667"
+                      >
+                        04/06
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="313.8333333333333"
+                      x2="313.8333333333333"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="313.8333333333333"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="313.8333333333333"
+                      >
+                        04/07
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="321.5"
+                      x2="321.5"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="321.5"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="321.5"
+                      >
+                        04/08
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="329.1666666666667"
+                      x2="329.1666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="329.1666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="329.1666666666667"
+                      >
+                        04/09
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="336.8333333333333"
+                      x2="336.8333333333333"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="336.8333333333333"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="336.8333333333333"
+                      >
+                        04/10
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="344.5"
+                      x2="344.5"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="344.5"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="344.5"
+                      >
+                        04/11
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="352.1666666666667"
+                      x2="352.1666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="352.1666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="352.1666666666667"
+                      >
+                        04/12
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="359.8333333333333"
+                      x2="359.8333333333333"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="359.8333333333333"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="359.8333333333333"
+                      >
+                        04/13
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="367.5"
+                      x2="367.5"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="367.5"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="367.5"
+                      >
+                        04/14
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="375.1666666666667"
+                      x2="375.1666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="375.1666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="375.1666666666667"
+                      >
+                        04/15
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="382.8333333333333"
+                      x2="382.8333333333333"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="382.8333333333333"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="382.8333333333333"
+                      >
+                        04/16
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="390.5"
+                      x2="390.5"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="390.5"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="390.5"
+                      >
+                        04/17
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="398.1666666666667"
+                      x2="398.1666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="398.1666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="398.1666666666667"
+                      >
+                        04/18
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="405.8333333333333"
+                      x2="405.8333333333333"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="405.8333333333333"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="405.8333333333333"
+                      >
+                        04/19
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="413.5"
+                      x2="413.5"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="413.5"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="413.5"
+                      >
+                        04/20
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="421.1666666666667"
+                      x2="421.1666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="421.1666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="421.1666666666667"
+                      >
+                        04/21
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="428.8333333333333"
+                      x2="428.8333333333333"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="428.8333333333333"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="428.8333333333333"
+                      >
+                        04/22
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="436.5"
+                      x2="436.5"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="436.5"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="436.5"
+                      >
+                        04/23
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="444.1666666666667"
+                      x2="444.1666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="444.1666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="444.1666666666667"
+                      >
+                        04/24
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="451.8333333333333"
+                      x2="451.8333333333333"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="451.8333333333333"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="451.8333333333333"
+                      >
+                        04/25
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="459.5"
+                      x2="459.5"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="459.5"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="459.5"
+                      >
+                        04/26
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="467.1666666666667"
+                      x2="467.1666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="467.1666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="467.1666666666667"
+                      >
+                        04/27
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="474.8333333333333"
+                      x2="474.8333333333333"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="474.8333333333333"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="474.8333333333333"
+                      >
+                        04/28
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="482.5"
+                      x2="482.5"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="482.5"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="482.5"
+                      >
+                        04/29
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="490.1666666666667"
+                      x2="490.1666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="490.1666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="490.1666666666667"
+                      >
+                        04/30
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="497.8333333333333"
+                      x2="497.8333333333333"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="497.8333333333333"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="497.8333333333333"
+                      >
+                        05/01
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="505.5"
+                      x2="505.5"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="505.5"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="505.5"
+                      >
+                        05/02
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="513.1666666666667"
+                      x2="513.1666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="513.1666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="513.1666666666667"
+                      >
+                        05/03
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="520.8333333333334"
+                      x2="520.8333333333334"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="520.8333333333334"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="520.8333333333334"
+                      >
+                        05/04
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="528.5000000000001"
+                      x2="528.5000000000001"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="528.5000000000001"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="528.5000000000001"
+                      >
+                        05/05
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="536.1666666666667"
+                      x2="536.1666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="536.1666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="536.1666666666667"
+                      >
+                        05/06
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="543.8333333333334"
+                      x2="543.8333333333334"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="543.8333333333334"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="543.8333333333334"
+                      >
+                        05/07
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="551.5000000000001"
+                      x2="551.5000000000001"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="551.5000000000001"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="551.5000000000001"
+                      >
+                        05/08
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="559.1666666666667"
+                      x2="559.1666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="559.1666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="559.1666666666667"
+                      >
+                        05/09
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="566.8333333333334"
+                      x2="566.8333333333334"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="566.8333333333334"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="566.8333333333334"
+                      >
+                        05/10
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="574.5000000000001"
+                      x2="574.5000000000001"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="574.5000000000001"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="574.5000000000001"
+                      >
+                        05/11
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="582.1666666666667"
+                      x2="582.1666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="582.1666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="582.1666666666667"
+                      >
+                        05/12
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="589.8333333333334"
+                      x2="589.8333333333334"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="589.8333333333334"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="589.8333333333334"
+                      >
+                        05/13
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="597.5000000000001"
+                      x2="597.5000000000001"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="597.5000000000001"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="597.5000000000001"
+                      >
+                        05/14
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="605.1666666666667"
+                      x2="605.1666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="605.1666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="605.1666666666667"
+                      >
+                        05/15
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="612.8333333333334"
+                      x2="612.8333333333334"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="612.8333333333334"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="612.8333333333334"
+                      >
+                        05/16
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="620.5000000000001"
+                      x2="620.5000000000001"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="620.5000000000001"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="620.5000000000001"
+                      >
+                        05/17
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="628.1666666666667"
+                      x2="628.1666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="628.1666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="628.1666666666667"
+                      >
+                        05/18
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="635.8333333333334"
+                      x2="635.8333333333334"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="635.8333333333334"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="635.8333333333334"
+                      >
+                        05/19
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="643.5000000000001"
+                      x2="643.5000000000001"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="643.5000000000001"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="643.5000000000001"
+                      >
+                        05/20
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="651.1666666666667"
+                      x2="651.1666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="651.1666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="651.1666666666667"
+                      >
+                        05/21
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="658.8333333333334"
+                      x2="658.8333333333334"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="658.8333333333334"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="658.8333333333334"
+                      >
+                        05/22
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="666.5000000000001"
+                      x2="666.5000000000001"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="666.5000000000001"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="666.5000000000001"
+                      >
+                        05/23
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="674.1666666666667"
+                      x2="674.1666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="674.1666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="674.1666666666667"
+                      >
+                        05/24
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="681.8333333333334"
+                      x2="681.8333333333334"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="681.8333333333334"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="681.8333333333334"
+                      >
+                        05/25
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="689.5000000000001"
+                      x2="689.5000000000001"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="689.5000000000001"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="689.5000000000001"
+                      >
+                        05/26
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="697.1666666666667"
+                      x2="697.1666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="697.1666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="697.1666666666667"
+                      >
+                        05/27
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="704.8333333333334"
+                      x2="704.8333333333334"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="704.8333333333334"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="704.8333333333334"
+                      >
+                        05/28
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="712.5000000000001"
+                      x2="712.5000000000001"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="712.5000000000001"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="712.5000000000001"
+                      >
+                        05/29
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="720.1666666666667"
+                      x2="720.1666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="720.1666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="720.1666666666667"
+                      >
+                        05/30
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="727.8333333333334"
+                      x2="727.8333333333334"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="727.8333333333334"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="727.8333333333334"
+                      >
+                        05/31
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="735.5000000000001"
+                      x2="735.5000000000001"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="735.5000000000001"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="735.5000000000001"
+                      >
+                        06/01
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="743.1666666666667"
+                      x2="743.1666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="743.1666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="743.1666666666667"
+                      >
+                        06/02
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="750.8333333333334"
+                      x2="750.8333333333334"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="750.8333333333334"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="750.8333333333334"
+                      >
+                        06/03
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="758.5000000000001"
+                      x2="758.5000000000001"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="758.5000000000001"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="758.5000000000001"
+                      >
+                        06/04
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="30"
+                      orientation="bottom"
+                      stroke="#666"
+                      width="690"
+                      x="80"
+                      x1="766.1666666666667"
+                      x2="766.1666666666667"
+                      y="765"
+                      y1="771"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="30"
+                      orientation="bottom"
+                      stroke="none"
+                      text-anchor="middle"
+                      width="690"
+                      x="766.1666666666667"
+                      y="773"
+                    >
+                      <tspan
+                        dy="0.71em"
+                        x="766.1666666666667"
+                      >
+                        06/05
+                      </tspan>
+                    </text>
+                  </g>
+                </g>
+              </g>
+              <g
+                class="recharts-layer recharts-cartesian-axis recharts-yAxis yAxis"
+              >
+                <line
+                  class="recharts-cartesian-axis-line"
+                  fill="none"
+                  height="745"
+                  orientation="left"
+                  stroke="#666"
+                  width="60"
+                  x="20"
+                  x1="80"
+                  x2="80"
+                  y="20"
+                  y1="20"
+                  y2="765"
+                />
+                <g
+                  class="recharts-cartesian-axis-ticks"
+                >
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="745"
+                      orientation="left"
+                      stroke="#666"
+                      width="60"
+                      x="20"
+                      x1="74"
+                      x2="80"
+                      y="20"
+                      y1="765"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="745"
+                      orientation="left"
+                      stroke="none"
+                      text-anchor="end"
+                      width="60"
+                      x="72"
+                      y="765"
+                    >
+                      <tspan
+                        dy="0.355em"
+                        x="72"
+                      >
+                        0
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="745"
+                      orientation="left"
+                      stroke="#666"
+                      width="60"
+                      x="20"
+                      x1="74"
+                      x2="80"
+                      y="20"
+                      y1="578.75"
+                      y2="578.75"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="745"
+                      orientation="left"
+                      stroke="none"
+                      text-anchor="end"
+                      width="60"
+                      x="72"
+                      y="578.75"
+                    >
+                      <tspan
+                        dy="0.355em"
+                        x="72"
+                      >
+                        150
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="745"
+                      orientation="left"
+                      stroke="#666"
+                      width="60"
+                      x="20"
+                      x1="74"
+                      x2="80"
+                      y="20"
+                      y1="392.5"
+                      y2="392.5"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="745"
+                      orientation="left"
+                      stroke="none"
+                      text-anchor="end"
+                      width="60"
+                      x="72"
+                      y="392.5"
+                    >
+                      <tspan
+                        dy="0.355em"
+                        x="72"
+                      >
+                        300
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="745"
+                      orientation="left"
+                      stroke="#666"
+                      width="60"
+                      x="20"
+                      x1="74"
+                      x2="80"
+                      y="20"
+                      y1="206.25"
+                      y2="206.25"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="745"
+                      orientation="left"
+                      stroke="none"
+                      text-anchor="end"
+                      width="60"
+                      x="72"
+                      y="206.25"
+                    >
+                      <tspan
+                        dy="0.355em"
+                        x="72"
+                      >
+                        450
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="745"
+                      orientation="left"
+                      stroke="#666"
+                      width="60"
+                      x="20"
+                      x1="74"
+                      x2="80"
+                      y="20"
+                      y1="20"
+                      y2="20"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="745"
+                      orientation="left"
+                      stroke="none"
+                      text-anchor="end"
+                      width="60"
+                      x="72"
+                      y="20"
+                    >
+                      <tspan
+                        dy="0.355em"
+                        x="72"
+                      >
+                        600
+                      </tspan>
+                    </text>
+                  </g>
+                </g>
+              </g>
+              <g
+                class="recharts-layer recharts-cartesian-axis recharts-yAxis yAxis"
+              >
+                <line
+                  class="recharts-cartesian-axis-line"
+                  fill="none"
+                  height="745"
+                  orientation="left"
+                  stroke="#666"
+                  width="60"
+                  x="20"
+                  x1="80"
+                  x2="80"
+                  y="20"
+                  y1="20"
+                  y2="765"
+                />
+                <g
+                  class="recharts-cartesian-axis-ticks"
+                >
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="745"
+                      orientation="left"
+                      stroke="#666"
+                      width="60"
+                      x="20"
+                      x1="74"
+                      x2="80"
+                      y="20"
+                      y1="765"
+                      y2="765"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="745"
+                      orientation="left"
+                      stroke="none"
+                      text-anchor="end"
+                      width="60"
+                      x="72"
+                      y="765"
+                    >
+                      <tspan
+                        dy="0.355em"
+                        x="72"
+                      >
+                        0
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="745"
+                      orientation="left"
+                      stroke="#666"
+                      width="60"
+                      x="20"
+                      x1="74"
+                      x2="80"
+                      y="20"
+                      y1="578.75"
+                      y2="578.75"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="745"
+                      orientation="left"
+                      stroke="none"
+                      text-anchor="end"
+                      width="60"
+                      x="72"
+                      y="578.75"
+                    >
+                      <tspan
+                        dy="0.355em"
+                        x="72"
+                      >
+                        150
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="745"
+                      orientation="left"
+                      stroke="#666"
+                      width="60"
+                      x="20"
+                      x1="74"
+                      x2="80"
+                      y="20"
+                      y1="392.5"
+                      y2="392.5"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="745"
+                      orientation="left"
+                      stroke="none"
+                      text-anchor="end"
+                      width="60"
+                      x="72"
+                      y="392.5"
+                    >
+                      <tspan
+                        dy="0.355em"
+                        x="72"
+                      >
+                        300
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="745"
+                      orientation="left"
+                      stroke="#666"
+                      width="60"
+                      x="20"
+                      x1="74"
+                      x2="80"
+                      y="20"
+                      y1="206.25"
+                      y2="206.25"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="745"
+                      orientation="left"
+                      stroke="none"
+                      text-anchor="end"
+                      width="60"
+                      x="72"
+                      y="206.25"
+                    >
+                      <tspan
+                        dy="0.355em"
+                        x="72"
+                      >
+                        450
+                      </tspan>
+                    </text>
+                  </g>
+                  <g
+                    class="recharts-layer recharts-cartesian-axis-tick"
+                  >
+                    <line
+                      class="recharts-cartesian-axis-tick-line"
+                      fill="none"
+                      height="745"
+                      orientation="left"
+                      stroke="#666"
+                      width="60"
+                      x="20"
+                      x1="74"
+                      x2="80"
+                      y="20"
+                      y1="20"
+                      y2="20"
+                    />
+                    <text
+                      class="recharts-text recharts-cartesian-axis-tick-value"
+                      fill="#666"
+                      height="745"
+                      orientation="left"
+                      stroke="none"
+                      text-anchor="end"
+                      width="60"
+                      x="72"
+                      y="20"
+                    >
+                      <tspan
+                        dy="0.355em"
+                        x="72"
+                      >
+                        600
+                      </tspan>
+                    </text>
+                  </g>
+                </g>
+              </g>
+              <g
+                class="recharts-layer recharts-bar"
+              >
+                <g
+                  class="recharts-layer recharts-bar-rectangles"
+                >
+                  <g
+                    class="recharts-layer"
+                  >
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                  </g>
+                </g>
+              </g>
+              <g
+                class="recharts-layer recharts-bar"
+              >
+                <g
+                  class="recharts-layer recharts-bar-rectangles"
+                >
+                  <g
+                    class="recharts-layer"
+                  >
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                  </g>
+                </g>
+              </g>
+              <g
+                class="recharts-layer recharts-bar"
+              >
+                <g
+                  class="recharts-layer recharts-bar-rectangles"
+                >
+                  <g
+                    class="recharts-layer"
+                  >
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                    <g
+                      class="recharts-layer recharts-bar-rectangle"
+                    />
+                  </g>
+                </g>
+              </g>
+            </svg>
+            <div
+              class="recharts-legend-wrapper"
+              style="position: absolute; width: 750px; height: auto; left: 20px; bottom: 5px;"
+            >
+              <ul
+                class="recharts-default-legend"
+                style="padding: 0px; margin: 0px; text-align: center;"
+              >
+                <li
+                  class="recharts-legend-item legend-item-0"
+                  style="display: inline-block; margin-right: 10px;"
+                >
+                  <svg
+                    class="recharts-surface"
+                    height="14"
+                    style="display: inline-block; vertical-align: middle; margin-right: 4px;"
+                    viewBox="0 0 32 32"
+                    width="14"
+                  >
+                    <title />
+                    <desc />
+                    <path
+                      class="recharts-legend-icon"
+                      d="M0,4h32v24h-32z"
+                      fill="#FEC20A"
+                      stroke="none"
+                    />
+                  </svg>
+                  <span
+                    class="recharts-legend-item-text"
+                    style="color: rgb(254, 194, 10);"
+                  >
+                    Active
+                  </span>
+                </li>
+                <li
+                  class="recharts-legend-item legend-item-1"
+                  style="display: inline-block; margin-right: 10px;"
+                >
+                  <svg
+                    class="recharts-surface"
+                    height="14"
+                    style="display: inline-block; vertical-align: middle; margin-right: 4px;"
+                    viewBox="0 0 32 32"
+                    width="14"
+                  >
+                    <title />
+                    <desc />
+                    <path
+                      class="recharts-legend-icon"
+                      d="M0,4h32v24h-32z"
+                      fill="#D56EEF"
+                      stroke="none"
+                    />
+                  </svg>
+                  <span
+                    class="recharts-legend-item-text"
+                    style="color: rgb(213, 110, 239);"
+                  >
+                    Liquidated
+                  </span>
+                </li>
+                <li
+                  class="recharts-legend-item legend-item-2"
+                  style="display: inline-block; margin-right: 10px;"
+                >
+                  <svg
+                    class="recharts-surface"
+                    height="14"
+                    style="display: inline-block; vertical-align: middle; margin-right: 4px;"
+                    viewBox="0 0 32 32"
+                    width="14"
+                  >
+                    <title />
+                    <desc />
+                    <path
+                      class="recharts-legend-icon"
+                      d="M0,4h32v24h-32z"
+                      fill="#3292D7"
+                      stroke="none"
+                    />
+                  </svg>
+                  <span
+                    class="recharts-legend-item-text"
+                    style="color: rgb(50, 146, 215);"
+                  >
+                    Closed
+                  </span>
+                </li>
+              </ul>
+            </div>
+            <div
+              class="recharts-tooltip-wrapper"
+              role="dialog"
+              style="transform: translate(undefinedpx, undefinedpx); pointer-events: none; visibility: hidden; position: absolute; top: 0px; left: 0px;"
+              tabindex="-1"
+            >
+              <div
+                class="recharts-default-tooltip"
+                style="margin: 0px; padding: 10px; background-color: rgb(255, 255, 255); border: 1px solid #ccc; white-space: nowrap;"
+              >
+                <p
+                  class="recharts-tooltip-label"
+                  style="margin: 0px;"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
     <hr
       class="my-5"
     />
@@ -140,7 +6081,52 @@ exports[`Liquidation Dashboard Snapshot tests should match snapshot when data is
                   <div
                     class="text-right"
                   >
+                    Liquidation Ratio
+                  </div>
+                </button>
+              </th>
+              <th
+                class="h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0"
+                style="width: 150px;"
+              >
+                <button
+                  class="text-left w-full"
+                  type="button"
+                >
+                  <div
+                    class="text-right"
+                  >
+                    Liquidation Price
+                  </div>
+                </button>
+              </th>
+              <th
+                class="h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0"
+                style="width: 150px;"
+              >
+                <button
+                  class="text-left w-full"
+                  type="button"
+                >
+                  <div
+                    class="text-right"
+                  >
                     Collateral Returned Amount
+                  </div>
+                </button>
+              </th>
+              <th
+                class="h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0"
+                style="width: 150px;"
+              >
+                <button
+                  class="text-left w-full"
+                  type="button"
+                >
+                  <div
+                    class="text-right"
+                  >
+                    Collateral Returned ($USD)
                   </div>
                 </button>
               </th>
@@ -193,7 +6179,34 @@ exports[`Liquidation Dashboard Snapshot tests should match snapshot when data is
                 <div
                   class="text-right font-medium"
                 >
+                  230%
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
+                  $8.72
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
                   4.042
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
+                  $6.87
                 </div>
               </td>
             </tr>
@@ -241,7 +6254,34 @@ exports[`Liquidation Dashboard Snapshot tests should match snapshot when data is
                 <div
                   class="text-right font-medium"
                 >
+                  190%
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
+                  $13.46
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
                   3.749
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
+                  $4.61
                 </div>
               </td>
             </tr>
@@ -289,7 +6329,34 @@ exports[`Liquidation Dashboard Snapshot tests should match snapshot when data is
                 <div
                   class="text-right font-medium"
                 >
+                  200%
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
+                  $26.03
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
                   16.157
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
+                  $36.03
                 </div>
               </td>
             </tr>
@@ -337,7 +6404,34 @@ exports[`Liquidation Dashboard Snapshot tests should match snapshot when data is
                 <div
                   class="text-right font-medium"
                 >
+                  170%
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
+                  $1.13
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
                   0.001
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
+                  $0.00
                 </div>
               </td>
             </tr>
@@ -385,7 +6479,34 @@ exports[`Liquidation Dashboard Snapshot tests should match snapshot when data is
                 <div
                   class="text-right font-medium"
                 >
+                  100%
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
+                  $4.92
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
                   921.651
+                </div>
+              </td>
+              <td
+                class="p-4 align-middle [&:has([role=checkbox])]:pr-0"
+              >
+                <div
+                  class="text-right font-medium"
+                >
+                  $949.30
                 </div>
               </td>
             </tr>
@@ -433,6 +6554,35 @@ exports[`Liquidation Dashboard Snapshot tests should match snapshot when data is
             />
           </div>
         </div>
+      </div>
+    </div>
+    <div
+      class="rounded-lg border bg-card text-card-foreground shadow-sm my-4 mb-4"
+    >
+      <div
+        class="flex flex-col space-y-1.5 p-6"
+      >
+        <h3
+          class="text-2xl font-semibold leading-none tracking-tight"
+        >
+          Vault States
+        </h3>
+      </div>
+      <div
+        class="p-6 pt-0"
+      >
+        <div
+          class="animate-pulse bg-muted w-full h-[20px] rounded-full mb-2"
+        />
+        <div
+          class="animate-pulse bg-muted w-full h-[20px] rounded-full mb-2"
+        />
+        <div
+          class="animate-pulse bg-muted w-full h-[20px] rounded-full mb-2"
+        />
+        <div
+          class="animate-pulse bg-muted w-full h-[20px] rounded-full mb-2"
+        />
       </div>
     </div>
     <hr


### PR DESCRIPTION
It reverts #86 to reveal the liquidations graph again