### PR TITLE
chore: update subquery url

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ export const VBANK_RESERVE_ACCOUNT = 'vbank/reserve';
 
 export const GRAPH_DAYS = 90;
 
-export const SUBQUERY_URL = 'https://api.subquery.network/sq/agoric-labs/agoric-mainnet-v2';
+export const SUBQUERY_URL = 'https://index-api.onfinality.io/sq/agoric-labs/agoric-mainnet-v2';
 
 export const enum VAULT_STATES {
   ACTIVE = 'active',

--- a/workers/apis/src/constants.js
+++ b/workers/apis/src/constants.js
@@ -1,3 +1,3 @@
 export const balancesKey = 'balances';
 export const BASE_NODE_URL = 'https://main-a.api.agoric.net:443';
-export const SUBQUERY_URL = 'https://api.subquery.network/sq/agoric-labs/agoric-mainnet-v2';
+export const SUBQUERY_URL = 'https://index-api.onfinality.io/sq/agoric-labs/agoric-mainnet-v2';


### PR DESCRIPTION
Onfinality has changed the API URL. Right now both the old and new ones work so changing it pre-emptively on the inter dashboard. 

<img width="577" alt="image" src="https://github.com/user-attachments/assets/7c959df4-41b5-4e03-a1c5-d30abfffb6d5" />

Will be re-deploying the production indexer today so the old one will stop working as soon as its done.